### PR TITLE
Splitter fixes, null pointer exception

### DIFF
--- a/src/com/bfh/logisim/hdlgenerator/HDLColorRenderer.java
+++ b/src/com/bfh/logisim/hdlgenerator/HDLColorRenderer.java
@@ -54,13 +54,13 @@ public class HDLColorRenderer extends JLabel
 			setBorder(border);
 		} else {
 			String myInfo = (String) Info;
-			if (myInfo.equals(RequiredFieldString)) {
+			if (myInfo != null && myInfo.equals(RequiredFieldString)) {
 				setBackground(Color.YELLOW);
 				setForeground(Color.BLUE);
 				setText("HDL Required");
 				setHorizontalAlignment(JLabel.CENTER);
 				setBorder(null);
-			} else if (myInfo.contains("#")&& myInfo.indexOf('#')==0&&
+			} else if (myInfo != null && myInfo.contains("#")&& myInfo.indexOf('#')==0&&
 					   (myInfo.length() == 7 || myInfo.length() == 9)) {
 				int red,green,blue,alpha;				
 				red = Integer.valueOf(myInfo.substring(1, 3), 16);

--- a/src/com/cburch/logisim/circuit/Wire.java
+++ b/src/com/cburch/logisim/circuit/Wire.java
@@ -78,7 +78,7 @@ public final class Wire implements Component, AttributeSet, CustomHandles,
 	public static final int WIDTH_BUS = 4;
 	public static final int HIGHLIGHTED_WIDTH = 4;
 	public static final int HIGHLIGHTED_WIDTH_BUS = 5;
-	public static final double DOT_MULTIPLY_FACTOR = 1.5; /* multiply factor for the intersection points */
+	public static final double DOT_MULTIPLY_FACTOR = 1.35; /* multiply factor for the intersection points */
 	public static final AttributeOption VALUE_HORZ = new AttributeOption(
 			"horz", Strings.getter("wireDirectionHorzOption"));
 	public static final AttributeOption VALUE_VERT = new AttributeOption(


### PR DESCRIPTION
Issues were arising where changing the bits and fanout on a splitter connected to an input would throw NullPointerExceptions. The second commit guards against these changes, the first commit is merely style changes to not have the dots overlapping when close with a wire bus.