### PR TITLE
Added intellij related entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ com/hepia
 javadoc/
 test/com/cburch/logisim/gui
 bin/
+out/
 
 # additional libraries
 !libs/*.jar
@@ -58,7 +59,8 @@ bin/
 .settings/
 .project
 .classpath
-
+.idea/
+*.iml
 
 # Simulation files and folders
 resources/logisim/sim/comp.tcl


### PR DESCRIPTION
/.idea is IDE settings, .iml files are autogenerated on importing to intellij despite not being used in the ant build process. /out is where intellij sticks the class files if you ignore the readme's instructions and just try to build from Build>Build Project (guilty).