### PR TITLE
Fix compilation error due to unknown class ScaledOptionPane

### DIFF
--- a/src/com/cburch/logisim/Main.java
+++ b/src/com/cburch/logisim/Main.java
@@ -33,11 +33,11 @@ package com.cburch.logisim;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import javax.swing.JOptionPane;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.cburch.logisim.gui.scale.ScaledOptionPane;
 import com.cburch.logisim.gui.start.Startup;
 
 public class Main {
@@ -55,7 +55,7 @@ public class Main {
 					Writer result = new StringWriter();
 					PrintWriter printWriter = new PrintWriter(result);
 					e.printStackTrace(printWriter);
-					ScaledOptionPane.showMessageDialog(null, result.toString());
+					JOptionPane.showMessageDialog(null, result.toString());
 					System.exit(-1);
 				}
 			}


### PR DESCRIPTION
The scaling_resolution_wip branch @ 4c96148 fails to build due to unknown class ```com.cburch.logisim.gui.scale.ScaledOptionPane```.