### PR TITLE
Fix the DEB postrm script to delete the logisim-evolution command line tool

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
 	xmlns:fx="javafx:com.sun.javafx.tools.ant">
 
 	<property name="app.name" value="Logisim-evolution"/>
-	<property name="app.version" value="2.13.23"/>
+	<property name="app.version" value="2.14.1"/>
 
     <target name="cleanall" depends="clean">
         <delete dir="bin/com/bfh/"/>

--- a/package/linux/postrm
+++ b/package/linux/postrm
@@ -23,7 +23,6 @@ case "$1" in
         echo "Uninstalling command line tool logisim-evolution"
         rm /usr/bin/logisim-evolution
         if [ "$1" = "purge" ] ; then
-
             if [ "false" = "true" ]; then
                 echo "Uninstalling daemon"
                 rm -f /etc/init.d/logisim-evolution

--- a/package/linux/postrm
+++ b/package/linux/postrm
@@ -20,9 +20,9 @@ set -e
 
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        echo "Uninstalling command line tool logisim-evolution"
+        rm /usr/bin/logisim-evolution
         if [ "$1" = "purge" ] ; then
-            echo "Uninstalling command line tool logisim-evolution"
-            rm /usr/bin/logisim-evolution
 
             if [ "false" = "true" ]; then
                 echo "Uninstalling daemon"


### PR DESCRIPTION
Without this fix, the logisim-evolution command line tool in /usr/bin is only deleted when purging the Debian package. In consequence, upgrading the Debian package failed.

The PR also updates the Logisim-evolution package version to 2.14.1 in the build.xml file. Keeping the version information in two locations is unsatisfying, as they can easily get out-of-sync. Maybe, someone has an idea how to centralize this information to a unique location. Also, you may consider to update the copyright year, it is still set to 2014...