### PR TITLE
Use "extends TreeNode" to fix compilaton with javac 1.8.0_144

### DIFF
--- a/src/com/cburch/logisim/gui/log/ComponentSelector.java
+++ b/src/com/cburch/logisim/gui/log/ComponentSelector.java
@@ -314,8 +314,8 @@ class ComponentSelector extends JTree {
 			this.option = option;
 		}
 
-		public Enumeration<?> children() {
-			return Collections.enumeration(Collections.emptySet());
+		public Enumeration<? extends TreeNode> children() {
+			return Collections.enumeration(Collections.<TreeNode>emptySet());
 		}
 
 		public boolean getAllowsChildren() {

--- a/src/com/cburch/logisim/gui/main/SimulationTreeNode.java
+++ b/src/com/cburch/logisim/gui/main/SimulationTreeNode.java
@@ -37,7 +37,7 @@ import javax.swing.tree.TreeNode;
 import com.cburch.logisim.comp.ComponentFactory;
 
 public abstract class SimulationTreeNode implements TreeNode {
-	public abstract Enumeration<?> children();
+	public abstract Enumeration<? extends TreeNode> children();
 
 	public abstract boolean getAllowsChildren();
 


### PR DESCRIPTION
I am not sure why compiling the master branch on my machine throws these errors, it could be related to my environment (JDK 8u144 on macOS High Sierra). I attached the build output below. This commit fixes the aforementioned errors. Maybe I'm missing something else, any hint would be appreciated.

```
compile:
    [javac] Compiling 791 source files to /Users/nicolas/development/logisim-evolution/bin
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.7
    [javac] /Users/nicolas/development/logisim-evolution/src/com/cburch/logisim/gui/main/SimulationTreeNode.java:40: error: children() in SimulationTreeNode cannot implement children() in TreeNode
    [javac] 	public abstract Enumeration<?> children();
    [javac] 	                               ^
    [javac]   return type Enumeration<?> is not compatible with Enumeration<? extends TreeNode>
    [javac] /Users/nicolas/development/logisim-evolution/src/com/cburch/logisim/gui/log/ComponentSelector.java:308: error: ComponentSelector.OptionNode is not abstract and does not override abstract method children() in TreeNode
    [javac] 	private class OptionNode implements TreeNode {
    [javac] 	        ^
    [javac] /Users/nicolas/development/logisim-evolution/src/com/cburch/logisim/gui/log/ComponentSelector.java:317: error: children() in ComponentSelector.OptionNode cannot implement children() in TreeNode
    [javac] 		public Enumeration<?> children() {
    [javac] 		                      ^
    [javac]   return type Enumeration<?> is not compatible with Enumeration<? extends TreeNode>
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] 3 errors
    [javac] 1 warning
```

