### PR TITLE
Prevent XXE when loading circuit files

### DIFF
--- a/src/com/cburch/logisim/file/XmlReader.java
+++ b/src/com/cburch/logisim/file/XmlReader.java
@@ -46,6 +46,7 @@ import javax.swing.JOptionPane;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.XMLConstants;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1042,6 +1043,11 @@ class XmlReader {
 			IOException {
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(true);
+		try {
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		} catch (ParserConfigurationException ex) {
+			// All implementations are required to support FEATURE_SECURE_PROCESSING.
+		}
 		DocumentBuilder builder = null;
 		try {
 			builder = factory.newDocumentBuilder();


### PR DESCRIPTION
This prevents issues with XXE (XML external entity) processing,
particularly for untrusted circuit files. This is potentially dangerous,
since it lets an attacker with a crafted circuit file to read files from
a user's system. I have verified that it is possible to create a circuit
file which does this. With this patch, an error message is displayed
instead of XXE occurring.

Some examples of XXE are available on [on OWASP](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing).

This patch doesn't make any breaking changes with existing circuit
files, it only prevents loading malicious circuit files.