### PR TITLE
Fix issues #135 and #142

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
 	xmlns:fx="javafx:com.sun.javafx.tools.ant">
 
 	<property name="app.name" value="Logisim-evolution"/>
-	<property name="app.version" value="2.14.1"/>
+	<property name="app.version" value="2.14.3"/>
 
     <target name="cleanall" depends="clean">
         <delete dir="bin/com/bfh/"/>
@@ -74,15 +74,19 @@
         <java jar="logisim-evolution.jar" fork="true"/>
     </target>
 
+    <!-- Task package will fail on macOS High Sierra while generating a DMG
+         due to bug JDK-8190758. Use task package_macos instead to generate
+         an app bundle. -->
     <target name="package" depends="jar">
         <taskdef resource="com/sun/javafx/tools/ant/antlib.xml"
                  uri="javafx:com.sun.javafx.tools.ant"
-                 classpath=".:${java.home}/../lib/ant-javafx.jar"/>
+                 classpath=".:${java.home}/lib/ant-javafx.jar"/>
         <fx:deploy width="600" height="400"
                    embeddedWidth="100%" embeddedHeight="100%"
                    outdir="${basedir}/package"
                    outfile="${app.name}"
                    nativeBundles="all"
+                   signBundle="false"
                    verbose="true">
 
             <fx:application name="${app.name}"
@@ -91,7 +95,8 @@
                             toolkit="swing"
             />
             <!-- Package only application and dependencies but not the JRE -->
-            <fx:platform basedir=""/>
+            <!-- Unfortunately, removed in JDK 9. No workaround known yet. -->
+            <!-- <fx:platform basedir=""/> -->
 
             <fx:resources>
                 <fx:fileset dir="." includes="logisim-evolution.jar"/>
@@ -101,7 +106,7 @@
                      vendor="${app.name} development team"
                      description="${app.name} for design and simulation of digital logic circuits"
                      category="Engineering"
-                     copyright="Copyright (C) 2001--2017 Carl Burch, BFH, HEIG-VD, HEPIA, et al."
+                     copyright="Copyright (C) 2001--2018 Carl Burch, BFH, HEIG-VD, HEPIA, et al."
                      license="GNU GENERAL PUBLIC LICENSE, version 3"
             >
                 <fx:association extension="circ" mimetype="application-prs.cburch.logisim" description="${app.name} circuit file"/>
@@ -113,6 +118,68 @@
             <fx:bundleArgument arg="mac.CFBundleName" value="Logisim"/>
             <fx:bundleArgument arg="mac.CFBundleIdentifier" value="com.cburch.logisim"/>
             <fx:bundleArgument arg="win.menuGroup" value="Engineering"/>
+            <fx:bundleArgument arg="signBundle" value="false"/>
+            <fx:bundleArgument arg="dropinResourcesRoot" value="${basedir}"/>
+
+            <fx:preferences install="true"
+                            installDirChooser="true"
+                            menu="true"/>
         </fx:deploy>
     </target>
+
+    <!-- DMG generation is broken on macOS High Sierra, cf. to
+         https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8190758 for
+         details. Problem is only fixed in JDK 8u162 and the upcoming JDK 10.
+         There is no fix for JDK 9. This task package_macos works around the
+         problem by only generating a pkg installer. -->
+    <target name="package_macos" depends="jar">
+        <taskdef resource="com/sun/javafx/tools/ant/antlib.xml"
+                 uri="javafx:com.sun.javafx.tools.ant"
+                 classpath=".:${java.home}/lib/ant-javafx.jar"/>
+        <fx:deploy width="600" height="400"
+                   embeddedWidth="100%" embeddedHeight="100%"
+                   outdir="${basedir}/package"
+                   outfile="${app.name}"
+                   nativeBundles="pkg"
+                   signBundle="false"
+                   verbose="true">
+
+            <fx:application name="${app.name}"
+                            mainClass="com.cburch.logisim.Main"
+                            version="${app.version}"
+                            toolkit="swing"
+            />
+            <!-- Package only application and dependencies but not the JRE -->
+            <!-- Unfortunately, removed in JDK 9. No workaround known yet. -->
+            <!-- <fx:platform basedir=""/> -->
+
+            <fx:resources>
+                <fx:fileset dir="." includes="logisim-evolution.jar"/>
+            </fx:resources>
+
+            <fx:info title="${app.name}"
+                     vendor="${app.name} development team"
+                     description="${app.name} for design and simulation of digital logic circuits"
+                     category="Engineering"
+                     copyright="Copyright (C) 2001--2018 Carl Burch, BFH, HEIG-VD, HEPIA, et al."
+                     license="GNU GENERAL PUBLIC LICENSE, version 3"
+            >
+                <fx:association extension="circ" mimetype="application-prs.cburch.logisim" description="${app.name} circuit file"/>
+            </fx:info>
+            <fx:bundleArgument arg="email" value="roberto.rigamonti@heig-vd.ch"/>
+            <fx:bundleArgument arg="linux.bundleName" value="logisim-evolution"/>
+            <!-- See https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8 for list of AppStore categories -->
+            <fx:bundleArgument arg="mac.category" value="public.app-category.education"/>
+            <fx:bundleArgument arg="mac.CFBundleName" value="Logisim"/>
+            <fx:bundleArgument arg="mac.CFBundleIdentifier" value="com.cburch.logisim"/>
+            <fx:bundleArgument arg="win.menuGroup" value="Engineering"/>
+            <fx:bundleArgument arg="signBundle" value="false"/>
+            <fx:bundleArgument arg="dropinResourcesRoot" value="${basedir}"/>
+
+            <fx:preferences install="true"
+                            installDirChooser="true"
+                            menu="true"/>
+        </fx:deploy>
+    </target>
+
 </project>

--- a/package/macosx/Info.plist
+++ b/package/macosx/Info.plist
@@ -1,0 +1,92 @@
+<?xml version="1.0" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+ <dict>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.9</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleAllowMixedLocalizations</key>
+  <true/>
+  <key>CFBundleExecutable</key>
+  <string>Logisim-evolution</string>
+  <key>CFBundleIconFile</key>
+  <string>Logisim-evolution.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.cburch.logisim</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Logisim</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>2.14.3</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <!-- See http://developer.apple.com/library/mac/#releasenotes/General/SubmittingToMacAppStore/_index.html
+       for list of AppStore categories -->
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.education</string>
+  <key>CFBundleVersion</key>
+  <string>2.14.3</string>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright (C) 2001--2018 Carl Burch, BFH, HEIG-VD, HEPIA, et al.</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>com.cburch.logisim.circ</string>
+      </array>
+
+      <key>CFBundleTypeName</key>
+      <string>Logisim-evolution circuit file</string>
+
+      <key>LSHandlerRank</key>
+      <string>Owner</string>
+
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+
+      <key>LSIsAppleDefaultForType</key>
+      <true/>
+
+    </dict>
+  </array>
+
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>com.cburch.logisim.circ</string>
+
+      <key>UTTypeDescription</key>
+      <string>Logisim-evolution circuit file</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+          <string>public.data</string>
+      </array>
+
+
+      <key>UTTypeTagSpecification</key>
+      <dict>
+
+        <key>public.filename-extension</key>
+        <array>
+          <string>circ</string>
+        </array>
+        <key>public.mime-type</key>
+        <array>
+          <string>application-prs.cburch.logisim</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
+
+  <key>NSHighResolutionCapable</key>
+  <string>true</string>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <string>true</string>
+ </dict>
+</plist>


### PR DESCRIPTION
See the commit messages for details. The modified ```build.xml``` works for me with JDK 9.0.1 on macOS High Sierra. Testing on other platforms is needed.

The addition of ```Info.plist``` to fix issue #142 introduces unfortunately yet a third place in which the version of Logisim-evolution is mentioned, which has to be kept in sync for the displayed version numbers to stay consistent. It would be good to somehow update the version number in the Java sources and Info.plist through some ant task.