### PR TITLE
Added missing import

### DIFF
--- a/src/com/cburch/logisim/std/arith/Multiplier.java
+++ b/src/com/cburch/logisim/std/arith/Multiplier.java
@@ -45,6 +45,7 @@ import com.cburch.logisim.instance.InstanceFactory;
 import com.cburch.logisim.instance.InstancePainter;
 import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.instance.Port;
+import com.cburch.logisim.instance.StdAttr;
 import com.cburch.logisim.tools.key.BitWidthConfigurator;
 import com.cburch.logisim.util.GraphicsUtil;
 


### PR DESCRIPTION
It currently does not compile without it.

```
compile:
    [mkdir] Created dir: /Users/leijurv/Downloads/logisim-evolution/bin
    [javac] Compiling 791 source files to /Users/leijurv/Downloads/logisim-evolution/bin
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.7
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:142: error: cannot find symbol
    [javac] 		setAttributes(new Attribute[] { StdAttr.WIDTH },
    [javac] 		                                ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:144: error: cannot find symbol
    [javac] 		setKeyConfigurator(new BitWidthConfigurator(StdAttr.WIDTH));
    [javac] 		                                            ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:149: error: cannot find symbol
    [javac] 		ps[IN0] = new Port(-40, -10, Port.INPUT, StdAttr.WIDTH);
    [javac] 		                                         ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:150: error: cannot find symbol
    [javac] 		ps[IN1] = new Port(-40, 10, Port.INPUT, StdAttr.WIDTH);
    [javac] 		                                        ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:151: error: cannot find symbol
    [javac] 		ps[OUT] = new Port(0, 0, Port.OUTPUT, StdAttr.WIDTH);
    [javac] 		                                      ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:152: error: cannot find symbol
    [javac] 		ps[C_IN] = new Port(-20, -20, Port.INPUT, StdAttr.WIDTH);
    [javac] 		                                          ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:153: error: cannot find symbol
    [javac] 		ps[C_OUT] = new Port(-20, 20, Port.OUTPUT, StdAttr.WIDTH);
    [javac] 		                                           ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/arith/Multiplier.java:195: error: cannot find symbol
    [javac] 		BitWidth dataWidth = state.getAttributeValue(StdAttr.WIDTH);
    [javac] 		                                             ^
    [javac]   symbol:   variable StdAttr
    [javac]   location: class Multiplier
    [javac] Note: /Users/leijurv/Downloads/logisim-evolution/src/com/cburch/logisim/std/hdl/VhdlSimulatorConsole.java uses or overrides a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] 8 errors
    [javac] 1 warning

BUILD FAILED
/Users/leijurv/Downloads/logisim-evolution/build.xml:31: Compile failed; see the compiler error output for details.

Total time: 5 seconds
```