### PR TITLE
Replace deprecated items

### DIFF
--- a/src/com/bfh/logisim/designrulecheck/Netlist.java
+++ b/src/com/bfh/logisim/designrulecheck/Netlist.java
@@ -568,7 +568,7 @@ public class Netlist implements CircuitListener {
 				return DRCStatus | CommonDRCStatus;
 			}
 			ConstructHierarchyTree(null, new ArrayList<String>(),
-					new Integer(0), new Integer(0), new Integer(0));
+					Integer.valueOf(0), Integer.valueOf(0), Integer.valueOf(0));
 			int ports = NumberOfInputPorts() + NumberOfOutputPorts()
 			+ LocalNrOfInportBubles + LocalNrOfOutportBubles
 			+ LocalNrOfInOutBubles;

--- a/src/com/bfh/logisim/fpgaboardeditor/ZoomSlider.java
+++ b/src/com/bfh/logisim/fpgaboardeditor/ZoomSlider.java
@@ -27,13 +27,13 @@ public class ZoomSlider extends JSlider {
 		 Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		 label = new JLabel("1.0x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(100), label);
+		 labelTable.put(Integer.valueOf(100), label);
 		 label = new JLabel("1.5x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(150), label);
+		 labelTable.put(Integer.valueOf(150), label);
 		 label = new JLabel("2.0x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(200), label);
+		 labelTable.put(Integer.valueOf(200), label);
 		 setLabelTable(labelTable);
 		 setPaintLabels(true);
 	 }

--- a/src/com/cburch/draw/tools/TextTool.java
+++ b/src/com/cburch/draw/tools/TextTool.java
@@ -202,7 +202,7 @@ public class TextTool extends AbstractTool {
 		double zoom = canvas.getZoomFactor();
 		fieldLoc.x = (int) Math.round(mx * zoom - fieldLoc.x);
 		fieldLoc.y = (int) Math.round(my * zoom - fieldLoc.y);
-		int caret = field.viewToModel(fieldLoc);
+		int caret = field.viewToModel2D(fieldLoc);
 		if (caret >= 0) {
 			field.setCaretPosition(caret);
 		}

--- a/src/com/cburch/hex/Caret.java
+++ b/src/com/cburch/hex/Caret.java
@@ -69,7 +69,7 @@ public class Caret {
 		public void keyPressed(KeyEvent e) {
 			int cols = hex.getMeasures().getColumnCount();
 			int rows;
-			boolean shift = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0;
+			boolean shift = (e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0;
 			switch (e.getKeyCode()) {
 			case KeyEvent.VK_UP:
 				if (cursor >= cols)
@@ -148,8 +148,8 @@ public class Caret {
 		}
 
 		public void keyTyped(KeyEvent e) {
-			int mask = e.getModifiers();
-			if ((mask & ~InputEvent.SHIFT_MASK) != 0)
+			int mask = e.getModifiersEx();
+			if ((mask & ~InputEvent.SHIFT_DOWN_MASK) != 0)
 				return;
 
 			char c = e.getKeyChar();
@@ -157,16 +157,16 @@ public class Caret {
 			switch (c) {
 			case ' ':
 				if (cursor >= 0)
-					setDot(cursor + 1, (mask & InputEvent.SHIFT_MASK) != 0);
+					setDot(cursor + 1, (mask & InputEvent.SHIFT_DOWN_MASK) != 0);
 				break;
 			case '\n':
 				if (cursor >= 0)
-					setDot(cursor + cols, (mask & InputEvent.SHIFT_MASK) != 0);
+					setDot(cursor + cols, (mask & InputEvent.SHIFT_DOWN_MASK) != 0);
 				break;
 			case '\u0008':
 			case '\u007f':
 				hex.delete();
-				// setDot(cursor - 1, (mask & InputEvent.SHIFT_MASK) != 0);
+				// setDot(cursor - 1, (mask & InputEvent.SHIFT_DOWN_MASK) != 0);
 				break;
 			default:
 				int digit = Character.digit(e.getKeyChar(), 16);
@@ -206,7 +206,7 @@ public class Caret {
 		public void mousePressed(MouseEvent e) {
 			Measures measures = hex.getMeasures();
 			long loc = measures.toAddress(e.getX(), e.getY());
-			setDot(loc, (e.getModifiers() & InputEvent.SHIFT_MASK) != 0);
+			setDot(loc, (e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0);
 			if (!hex.isFocusOwner())
 				hex.requestFocus();
 		}

--- a/src/com/cburch/logisim/analyze/gui/TableTabCaret.java
+++ b/src/com/cburch/logisim/analyze/gui/TableTabCaret.java
@@ -79,7 +79,7 @@ class TableTabCaret {
 			int inputs = model.getInputColumnCount();
 			int outputs = model.getOutputColumnCount();
 			int cols = inputs + outputs;
-			boolean shift = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0;
+			boolean shift = (e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0;
 			switch (e.getKeyCode()) {
 			case KeyEvent.VK_UP:
 				setCursor(cursorRow - 1, cursorCol, shift);
@@ -124,8 +124,8 @@ class TableTabCaret {
 		}
 
 		public void keyTyped(KeyEvent e) {
-			int mask = e.getModifiers();
-			if ((mask & ~InputEvent.SHIFT_MASK) != 0)
+			int mask = e.getModifiersEx();
+			if ((mask & ~InputEvent.SHIFT_DOWN_MASK) != 0)
 				return;
 
 			char c = e.getKeyChar();
@@ -160,12 +160,12 @@ class TableTabCaret {
 			case '\n':
 				setCursor(cursorRow + 1, table.getTruthTable()
 						.getInputColumnCount(),
-						(mask & InputEvent.SHIFT_MASK) != 0);
+						(mask & InputEvent.SHIFT_DOWN_MASK) != 0);
 				break;
 			case '\u0008':
 			case '\u007f':
 				setCursor(cursorRow, cursorCol - 1,
-						(mask & InputEvent.SHIFT_MASK) != 0);
+						(mask & InputEvent.SHIFT_DOWN_MASK) != 0);
 				break;
 			default:
 			}
@@ -207,7 +207,7 @@ class TableTabCaret {
 			table.requestFocus();
 			int row = table.getRow(e);
 			int col = table.getColumn(e);
-			setCursor(row, col, (e.getModifiers() & InputEvent.SHIFT_MASK) != 0);
+			setCursor(row, col, (e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0);
 		}
 
 		public void mouseReleased(MouseEvent e) {

--- a/src/com/cburch/logisim/comp/TextFieldCaret.java
+++ b/src/com/cburch/logisim/comp/TextFieldCaret.java
@@ -182,9 +182,9 @@ class TextFieldCaret implements Caret, TextFieldListener {
 	}
 
 	public void keyPressed(KeyEvent e) {
-		int ign = InputEvent.ALT_MASK | InputEvent.CTRL_MASK
-				| InputEvent.META_MASK;
-		if ((e.getModifiers() & ign) != 0)
+		int ign = InputEvent.ALT_DOWN_MASK | InputEvent.CTRL_DOWN_MASK
+				| InputEvent.META_DOWN_MASK;
+		if ((e.getModifiersEx() & ign) != 0)
 			return;
 		switch (e.getKeyCode()) {
 		case KeyEvent.VK_LEFT:
@@ -242,9 +242,9 @@ class TextFieldCaret implements Caret, TextFieldListener {
 	}
 
 	public void keyTyped(KeyEvent e) {
-		int ign = InputEvent.ALT_MASK | InputEvent.CTRL_MASK
-				| InputEvent.META_MASK;
-		if ((e.getModifiers() & ign) != 0)
+		int ign = InputEvent.ALT_DOWN_MASK | InputEvent.CTRL_DOWN_MASK
+				| InputEvent.META_DOWN_MASK;
+		if ((e.getModifiersEx() & ign) != 0)
 			return;
 
 		char c = e.getKeyChar();

--- a/src/com/cburch/logisim/data/TestVector.java
+++ b/src/com/cburch/logisim/data/TestVector.java
@@ -145,7 +145,7 @@ public class TestVector {
 										+ t);
 
 					columnName[i] = t.substring(0, s);
-					int w = new Integer(t.substring(s + 1, e)).intValue();
+					int w = Integer.parseInt(t.substring(s + 1, e));
 
 					if (w < 1 || w > 32)
 						throw new IOException(

--- a/src/com/cburch/logisim/file/Loader.java
+++ b/src/com/cburch/logisim/file/Loader.java
@@ -251,7 +251,7 @@ public class Loader implements LibraryLoader {
 		// instantiate library
 		Library ret;
 		try {
-			ret = (Library) retClass.newInstance();
+			ret = (Library) retClass.getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new LoadFailedException(StringUtil.format(
 					Strings.get("jarLibraryNotCreatedError"), className));

--- a/src/com/cburch/logisim/gui/main/KeyboardToolSelection.java
+++ b/src/com/cburch/logisim/gui/main/KeyboardToolSelection.java
@@ -46,7 +46,7 @@ public class KeyboardToolSelection extends AbstractAction {
 	public static void register(Toolbar toolbar) {
 		ActionMap amap = toolbar.getActionMap();
 		InputMap imap = toolbar.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-		int mask = toolbar.getToolkit().getMenuShortcutKeyMask();
+		int mask = toolbar.getToolkit().getMenuShortcutKeyMaskEx();
 		for (int i = 0; i < 10; i++) {
 			KeyStroke keyStroke = KeyStroke
 					.getKeyStroke((char) ('0' + i), mask);

--- a/src/com/cburch/logisim/gui/main/LayoutToolbarModel.java
+++ b/src/com/cburch/logisim/gui/main/LayoutToolbarModel.java
@@ -133,7 +133,7 @@ class LayoutToolbarModel extends AbstractToolbarModel {
 			if (index <= 10) {
 				if (index == 10)
 					index = 0;
-				int mask = frame.getToolkit().getMenuShortcutKeyMask();
+				int mask = frame.getToolkit().getMenuShortcutKeyMaskEx();
 				ret += " (" + InputEventUtil.toKeyDisplayString(mask) + "-"
 						+ index + ")";
 			}

--- a/src/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -124,7 +124,7 @@ class MenuEdit extends Menu {
 	public MenuEdit(LogisimMenuBar menubar) {
 		this.menubar = menubar;
 
-		int menuMask = getToolkit().getMenuShortcutKeyMask();
+		int menuMask = getToolkit().getMenuShortcutKeyMaskEx();
 		undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask));
 		redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, menuMask));
 		cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, menuMask));

--- a/src/com/cburch/logisim/gui/menu/MenuFile.java
+++ b/src/com/cburch/logisim/gui/menu/MenuFile.java
@@ -74,10 +74,10 @@ class MenuFile extends Menu implements ActionListener {
 		merge.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, menuMask));
 		open.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, menuMask));
 		close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, menuMask
-				| InputEvent.SHIFT_MASK));
+				| InputEvent.SHIFT_DOWN_MASK));
 		save.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, menuMask));
 		saveAs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, menuMask
-				| InputEvent.SHIFT_MASK));
+				| InputEvent.SHIFT_DOWN_MASK));
 		print.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, menuMask));
 		quit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, menuMask));
 

--- a/src/com/cburch/logisim/gui/menu/MenuFile.java
+++ b/src/com/cburch/logisim/gui/menu/MenuFile.java
@@ -68,7 +68,7 @@ class MenuFile extends Menu implements ActionListener {
 		this.menubar = menubar;
 		openRecent = new OpenRecent(menubar);
 
-		int menuMask = getToolkit().getMenuShortcutKeyMask();
+		int menuMask = getToolkit().getMenuShortcutKeyMaskEx();
 
 		newi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, menuMask));
 		merge.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, menuMask));

--- a/src/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/src/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -349,7 +349,7 @@ public class MenuSimulate extends Menu {
 		menubar.registerItem(LogisimMenuBar.TICK_STEP, tickOnce);
 		menubar.registerItem(LogisimMenuBar.TICK_STEP_MAIN, tickOnceMain);
 
-		int menuMask = getToolkit().getMenuShortcutKeyMask();
+		int menuMask = getToolkit().getMenuShortcutKeyMaskEx();
 		run.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, menuMask));
 		reset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, menuMask));
 		step.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, menuMask));
@@ -472,7 +472,7 @@ public class MenuSimulate extends Menu {
 		menu.removeAll();
 		menu.setEnabled(items.size() > 0);
 		boolean first = true;
-		int mask = getToolkit().getMenuShortcutKeyMask();
+		int mask = getToolkit().getMenuShortcutKeyMaskEx();
 		for (int i = items.size() - 1; i >= 0; i--) {
 			JMenuItem item = items.get(i);
 			menu.add(item);

--- a/src/com/cburch/logisim/gui/prefs/ZoomSlider.java
+++ b/src/com/cburch/logisim/gui/prefs/ZoomSlider.java
@@ -27,13 +27,13 @@ public class ZoomSlider extends JSlider {
 		 Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
 		 label = new JLabel("1.0x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(100), label);
+		 labelTable.put(Integer.valueOf(100), label);
 		 label = new JLabel("2.0x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(200), label);
+		 labelTable.put(Integer.valueOf(200), label);
 		 label = new JLabel("3.0x");
 		 label.setFont(AppPreferences.getScaledFont(label.getFont()));
-		 labelTable.put(new Integer(300), label);
+		 labelTable.put(Integer.valueOf(300), label);
 		 setLabelTable(labelTable);
 		 setPaintLabels(true);
 	 }

--- a/src/com/cburch/logisim/gui/test/Model.java
+++ b/src/com/cburch/logisim/gui/test/Model.java
@@ -241,9 +241,9 @@ class Model {
 			return;
 		for (int i = failed.size() + passed.size(); i < numPass + numFail; i++) {
 			if (results[i] == null)
-				passed.add(new Integer(i));
+				passed.add(Integer.valueOf(i));
 			else
-				failed.add(new Integer(i));
+				failed.add(Integer.valueOf(i));
 		}
 		fireTestResultsChanged();
 	}

--- a/src/com/cburch/logisim/instance/InstanceLoggerAdapter.java
+++ b/src/com/cburch/logisim/instance/InstanceLoggerAdapter.java
@@ -50,7 +50,7 @@ class InstanceLoggerAdapter implements Loggable {
 			Class<? extends InstanceLogger> loggerClass) {
 		try {
 			this.comp = comp;
-			this.logger = loggerClass.newInstance();
+			this.logger = loggerClass.getDeclaredConstructor().newInstance();
 			this.state = new InstanceStateImpl(null, comp);
 		} catch (Exception t) {
 			handleError(t, loggerClass);

--- a/src/com/cburch/logisim/instance/InstancePokerAdapter.java
+++ b/src/com/cburch/logisim/instance/InstancePokerAdapter.java
@@ -61,7 +61,7 @@ class InstancePokerAdapter extends AbstractCaret implements Pokable {
 			Class<? extends InstancePoker> pokerClass) {
 		try {
 			this.comp = comp;
-			poker = pokerClass.newInstance();
+			poker = pokerClass.getDeclaredConstructor().newInstance();
 		} catch (Exception t) {
 			handleError(t, pokerClass);
 			poker = null;

--- a/src/com/cburch/logisim/tools/FactoryDescription.java
+++ b/src/com/cburch/logisim/tools/FactoryDescription.java
@@ -128,7 +128,7 @@ public class FactoryDescription {
 				msg = "loading class";
 				Class<?> factoryClass = loader.loadClass(name);
 				msg = "creating instance";
-				Object factoryValue = factoryClass.newInstance();
+				Object factoryValue = factoryClass.getDeclaredConstructor().newInstance();
 				msg = "converting to factory";
 				if (factoryValue instanceof ComponentFactory) {
 					ret = (ComponentFactory) factoryValue;

--- a/src/com/cburch/logisim/tools/SelectTool.java
+++ b/src/com/cburch/logisim/tools/SelectTool.java
@@ -446,7 +446,7 @@ public class SelectTool extends Tool {
 		// selection is being modified
 		Collection<Component> in_sel = sel.getComponentsContaining(start, g);
 		if (!in_sel.isEmpty()) {
-			if ((e.getModifiers() & InputEvent.SHIFT_MASK) == 0) {
+			if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) == 0) {
 				setState(proj, MOVING);
 				proj.repaintCanvas();
 				return;
@@ -462,7 +462,7 @@ public class SelectTool extends Tool {
 		// wants to add/reset selection
 		Collection<Component> clicked = circuit.getAllContaining(start, g);
 		if (!clicked.isEmpty()) {
-			if ((e.getModifiers() & InputEvent.SHIFT_MASK) == 0) {
+			if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) == 0) {
 				if (sel.getComponentsContaining(start).isEmpty()) {
 					Action act = SelectionActions.dropAll(sel);
 					if (act != null) {
@@ -482,7 +482,7 @@ public class SelectTool extends Tool {
 
 		// The user clicked on the background. This is a rectangular
 		// selection (maybe with the shift key down).
-		if ((e.getModifiers() & InputEvent.SHIFT_MASK) == 0) {
+		if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) == 0) {
 			Action act = SelectionActions.dropAll(sel);
 			if (act != null) {
 				proj.doAction(act);

--- a/src/com/cburch/logisim/util/InputEventUtil.java
+++ b/src/com/cburch/logisim/util/InputEventUtil.java
@@ -30,7 +30,6 @@
 
 package com.cburch.logisim.util;
 
-import java.awt.Event;
 import java.awt.event.InputEvent;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -117,13 +116,13 @@ public class InputEventUtil {
 
 	public static String toKeyDisplayString(int mods) {
 		ArrayList<String> arr = new ArrayList<String>();
-		if ((mods & Event.META_MASK) != 0)
+		if ((mods & InputEvent.META_DOWN_MASK) != 0)
 			arr.add(Strings.get("metaMod"));
-		if ((mods & Event.CTRL_MASK) != 0)
+		if ((mods & InputEvent.CTRL_DOWN_MASK) != 0)
 			arr.add(Strings.get("ctrlMod"));
-		if ((mods & Event.ALT_MASK) != 0)
+		if ((mods & InputEvent.ALT_DOWN_MASK) != 0)
 			arr.add(Strings.get("altMod"));
-		if ((mods & Event.SHIFT_MASK) != 0)
+		if ((mods & InputEvent.SHIFT_DOWN_MASK) != 0)
 			arr.add(Strings.get("shiftMod"));
 
 		Iterator<String> it = arr.iterator();

--- a/src/com/cburch/logisim/util/LocaleManager.java
+++ b/src/com/cburch/logisim/util/LocaleManager.java
@@ -91,7 +91,7 @@ public class LocaleManager {
 			if (s != null) {
 				if (ret == null)
 					ret = new HashMap<Character, String>();
-				ret.put(new Character(c), s);
+				ret.put(Character.valueOf(c), s);
 			}
 		}
 		return ret;

--- a/src/com/cburch/logisim/util/TableSorter.java
+++ b/src/com/cburch/logisim/util/TableSorter.java
@@ -352,7 +352,7 @@ public class TableSorter extends AbstractTableModel {
 			// returns Object. We can't cast an Object to an int but we can
 			// cast it to an Integer and then extract the int from the Integer.
 			// But first, make sure it can be done.
-			Integer i = new Integer(0);
+			Integer i = Integer.valueOf(0);
 			if (!i.getClass().isInstance(retVal)) {
 				throw new ClassCastException();
 			}

--- a/src/com/cburch/logisim/util/WindowMenu.java
+++ b/src/com/cburch/logisim/util/WindowMenu.java
@@ -103,7 +103,7 @@ public class WindowMenu extends JMenu {
 		this.owner = owner;
 		WindowMenuManager.addMenu(this);
 
-		int menuMask = getToolkit().getMenuShortcutKeyMask();
+		int menuMask = getToolkit().getMenuShortcutKeyMaskEx();
 		minimize.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, menuMask));
 		close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, menuMask));
 

--- a/src/com/hepia/logisim/chronogui/RightPanel.java
+++ b/src/com/hepia/logisim/chronogui/RightPanel.java
@@ -140,9 +140,9 @@ public class RightPanel extends ChronoPanelTemplate {
 
 		defineSizes();
 
-		layeredPane.add(mCursor, new Integer(1));
-		layeredPane.add(mTimeLine, new Integer(0));
-		layeredPane.add(rightBox, new Integer(0));
+		layeredPane.add(mCursor, Integer.valueOf(1));
+		layeredPane.add(mTimeLine, Integer.valueOf(0));
+		layeredPane.add(rightBox, Integer.valueOf(0));
 
 		this.add(layeredPane, BorderLayout.WEST);
 	}


### PR DESCRIPTION
Replaced all deprecated items except for `show()` in `VhdlSimulatorConsole` (Implementation for `hide()` is needed to implement `setVisible(bool)`, which replaces `show()`).