### PR TITLE
Start using translated strings that were unused

### DIFF
--- a/src/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -114,10 +114,10 @@ class WindowOptions extends OptionsPanel {
 		
 		panel.add(new JLabel(" "));
 		panel.add(new JLabel(" "));
-		JLabel important = new JLabel(Strings.getter("windowToolbarPleaserestart"));
+		JLabel important = new JLabel(Strings.get("windowToolbarPleaserestart"));
 	    important.setFont(important.getFont().deriveFont(Font.ITALIC));
 	    panel.add(important);
-	    important = new JLabel(Strings.getter("windowToolbarImportant"));
+	    important = new JLabel(Strings.get("windowToolbarImportant"));
 	    important.setFont(important.getFont().deriveFont(Font.ITALIC));
 	    panel.add(important);
 		panel.add(ZoomLabel);
@@ -135,7 +135,7 @@ class WindowOptions extends OptionsPanel {
 			}
 			index++;
 		}
-		panel.add(new JLabel(Strings.getter("windowToolbarLookandfeel")));
+		panel.add(new JLabel(Strings.get("windowToolbarLookandfeel")));
 		panel.add(LookAndFeel);
 		LookAndFeel.addActionListener(Listener);
 

--- a/src/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -114,10 +114,10 @@ class WindowOptions extends OptionsPanel {
 		
 		panel.add(new JLabel(" "));
 		panel.add(new JLabel(" "));
-		JLabel important = new JLabel("Please restart logisim.");
+		JLabel important = new JLabel(Strings.getter("windowToolbarPleaserestart"));
 	    important.setFont(important.getFont().deriveFont(Font.ITALIC));
 	    panel.add(important);
-	    important = new JLabel("Important: changing the below values may have unpridictable results!");
+	    important = new JLabel(Strings.getter("windowToolbarImportant"));
 	    important.setFont(important.getFont().deriveFont(Font.ITALIC));
 	    panel.add(important);
 		panel.add(ZoomLabel);
@@ -135,7 +135,7 @@ class WindowOptions extends OptionsPanel {
 			}
 			index++;
 		}
-		panel.add(new JLabel("Look and Feel:"));
+		panel.add(new JLabel(Strings.getter("windowToolbarLookandfeel")));
 		panel.add(LookAndFeel);
 		LookAndFeel.addActionListener(Listener);
 


### PR DESCRIPTION
Logisim would use the default, hardcoded text instead of the translated strings, which are already available in some languages.