### PR TITLE
Change auto-update repository source

### DIFF
--- a/logisim_evolution_version.xml
+++ b/logisim_evolution_version.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logisim-evolution>
+  <file>https://github.com/reds-heig/logisim-evolution/releases/download/v2.15.0/logisim-evolution.jar</file>
+  <version>2.15.0</version>
+</logisim-evolution>

--- a/src/main/java/com/cburch/logisim/LogisimVersion.java
+++ b/src/main/java/com/cburch/logisim/LogisimVersion.java
@@ -184,14 +184,6 @@ public class LogisimVersion {
 		return (ret);
 	}
 
-	/**
-	 * If the considered Logisim version includes a tracker, returns true.
-	 * Assumption: the tracker is identified by a variant equals to "t"
-	 */
-	public boolean hasTracker() {
-		return (variant.equals("t"));
-	}
-
 	public String mainVersion() {
 		return (major + "." + minor + "." + release);
 	}

--- a/src/main/java/com/cburch/logisim/Main.java
+++ b/src/main/java/com/cburch/logisim/Main.java
@@ -97,6 +97,6 @@ public class Main {
 	/**
 	 * URL for the automatic updater
 	 */
-	public static final String UPDATE_URL = "http://reds-data.heig-vd.ch/logisim-evolution/logisim_evolution_version.xml";
+	public static final String UPDATE_URL = "https://raw.githubusercontent.com/leadrien/logisim-evolution/auto-update/logisim_evolution_version.xml";
 
 }

--- a/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlCircuitReader.java
@@ -68,9 +68,6 @@ public class XmlCircuitReader extends CircuitTransaction {
 	 */
 	static Component getComponent(Element elt, XmlReader.ReadContext reader)
 			throws XmlReaderException {
-		if (elt.getAttribute("trackercomp") != "" && !Main.VERSION.hasTracker()) {
-			return (null);
-		}
 
 		// Determine the factory that creates this element
 		String name = elt.getAttribute("name");

--- a/src/main/java/com/cburch/logisim/file/XmlReader.java
+++ b/src/main/java/com/cburch/logisim/file/XmlReader.java
@@ -370,15 +370,6 @@ class XmlReader {
 								JOptionPane.WARNING_MESSAGE);
 			}
 
-			if (versionString.contains("t") && !Main.VERSION.hasTracker()) {
-				JOptionPane
-						.showMessageDialog(
-								null,
-								"The file you have opened contains tracked components.\nYou might encounter some problems in the execution.",
-								"No tracking system available",
-								JOptionPane.WARNING_MESSAGE);
-			}
-
 			// first, load the sublibraries
 			for (Element o : XmlIterator.forChildElements(elt, "lib")) {
 				Library lib = toLibrary(o);

--- a/src/main/java/com/cburch/logisim/gui/start/Startup.java
+++ b/src/main/java/com/cburch/logisim/gui/start/Startup.java
@@ -562,9 +562,7 @@ public class Startup implements AWTEventListener {
 		Monitor.setProgress(2);
 
 		// Get the appropriate remote version number
-		LogisimVersion remoteVersion = LogisimVersion.parse(Main.VERSION
-				.hasTracker() ? logisimData.child("tracked_version").content()
-						: logisimData.child("untracked_version").content());
+		LogisimVersion remoteVersion = LogisimVersion.parse(logisimData.child("version").content());
 
 		// If the remote version is newer, perform the update
 		Monitor.setProgress(3);
@@ -601,9 +599,7 @@ public class Startup implements AWTEventListener {
 			}
 
 			// Get the appropriate remote filename to download
-			String remoteJar = Main.VERSION.hasTracker() ? logisimData.child(
-					"tracked_file").content() : logisimData.child(
-							"untracked_file").content();
+			String remoteJar = logisimData.child("file").content();
 
 					boolean updateOk = downloadInstallUpdatedVersion(remoteJar,
 							jarFile.getAbsolutePath());


### PR DESCRIPTION
We are still bounded to heig-vd servers for the auto-update.
The .xml containing the logisim version and the .jar to be downloaded are on reds-data.heig-vd.ch

This PR offers to have everything on github.
The jar is taken from github's releases folder and the logisim_evolution_version.xml is on the project root.

Note:
This PR remove support for auto-update of the tracked version.

Note 2:
To be able to test this PR, it needs to have the logisim_evolution_version.xml on github. (So it would require to merge the request to be able to test it...!)
So for test purpose, I set the UPDATE_URL (in Main.java) to target my own github repo. 
If you accept the PR, I will re-set this URL to this reds-heig/logisim-evolution repository
