### PR TITLE
Use app icon for document icon on Mac

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,7 @@ tasks {
                     "UTTypeIdentifier" to "com.cburch.logisim.circ",
                     "UTTypeDescription" to "Logisim-evolution circuit file",
                     "UTTypeConformsTo" to arrayOf("public.data"),
+                    "UTTypeIconFile" to "Logisim-evolution.icns",
                     "UTTypeTagSpecification" to
                     mapOf(
                         "public.filename-extension" to arrayOf("circ"),


### PR DESCRIPTION
This is a minor change in the Info.plist file for Macs that adds one key that maps the document icon to the Logisim-evolution icon. The result is that all .circ files on the Mac will have the app icon rather than the generic document icon. You may need to log out and back in or even reboot after opening the app with the Finder to get the Finder to start using the icon, since we are not using an app installer.