### PR TITLE
Rng

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitAttributes.java
@@ -155,19 +155,19 @@ public class CircuitAttributes extends AbstractAttributeSet {
 
 	private static final Attribute<?>[] STATIC_ATTRS = { NAME_ATTR,
 			CIRCUIT_LABEL_ATTR, CIRCUIT_LABEL_FACING_ATTR,
-			CIRCUIT_LABEL_FONT_ATTR,NAMED_CIRCUIT_BOX_FIXED_SIZE, 
-			CIRCUIT_VHDL_PATH,APPEARANCE_ATTR };
+			CIRCUIT_LABEL_FONT_ATTR,APPEARANCE_ATTR,NAMED_CIRCUIT_BOX_FIXED_SIZE, 
+			CIRCUIT_VHDL_PATH };
 
 	private static final Object[] STATIC_DEFAULTS = { "", "", Direction.EAST,
-			StdAttr.DEFAULT_LABEL_FONT, 
-			false, "", APPEAR_CLASSIC };
+			StdAttr.DEFAULT_LABEL_FONT, APPEAR_CLASSIC, 
+			false, "" };
 
 	private static final List<Attribute<?>> INSTANCE_ATTRS = Arrays
 			.asList(new Attribute<?>[] { StdAttr.FACING, StdAttr.LABEL,
 					LABEL_LOCATION_ATTR, StdAttr.LABEL_FONT,StdAttr.LABEL_VISIBILITY,
 					CircuitAttributes.NAME_ATTR, CIRCUIT_LABEL_ATTR,
-					CIRCUIT_LABEL_FACING_ATTR, CIRCUIT_LABEL_FONT_ATTR,
-					CIRCUIT_VHDL_PATH,APPEARANCE_ATTR });
+					CIRCUIT_LABEL_FACING_ATTR, CIRCUIT_LABEL_FONT_ATTR,APPEARANCE_ATTR,
+					CIRCUIT_VHDL_PATH });
 
 	private Circuit source;
 	private Instance subcircInstance;

--- a/src/main/resources/resources/logisim/en/circuit.properties
+++ b/src/main/resources/resources/logisim/en/circuit.properties
@@ -27,8 +27,8 @@ circuitLabelLocAttr = Label Location
 circuitLabelAttr = Shared Label
 circuitLabelDirAttr = Shared Label Facing
 circuitLabelFontAttr = Shared Label Font
-circuitNamedBox = Use new box layout
 circuitNamedBoxFixedSize = Use fixed box-size
+circuitAppearanceAttr = Appearance
 circuitIsVhdl = Reference to VHDL architecture?
 circuitVhdlPath = VHDL architecture file path
 #


### PR DESCRIPTION
Fixed "oscillation apparent" error with RNG component in case the initial seed is 0 and the reset input is activated. Note that this reset behavior will not be reproduced when loading the design on an FPGA board. Here the initial seed will always be restored in case of a reset.