### PR TITLE
Colorblind Color Scheme

### DIFF
--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -32,6 +32,7 @@ package com.cburch.logisim.data;
 
 import java.awt.Color;
 import java.util.Arrays;
+import com.cburch.logisim.prefs.AppPreferences;
 
 import com.cburch.logisim.util.Cache;
 
@@ -232,16 +233,16 @@ public class Value {
 	public static final Value NIL = new Value(0, 0, 0, 0);
 	public static final int MAX_WIDTH = 32;
 	public static final Color NIL_COLOR = Color.GRAY;
-	public static final Color FALSE_COLOR = new Color(0, 100, 0);
+	public static Color FALSE_COLOR;
 
-	public static final Color TRUE_COLOR = new Color(0, 210, 0);
+	public static Color TRUE_COLOR;
 
-	public static final Color UNKNOWN_COLOR = new Color(40, 40, 255);
+	public static Color UNKNOWN_COLOR;
 
 	public static final Color ERROR_COLOR = new Color(192, 0, 0);
 
-	public static final Color WIDTH_ERROR_COLOR = new Color(255, 123, 0);
-
+	public static Color WIDTH_ERROR_COLOR;
+	
 	public static final Color MULTI_COLOR = Color.BLACK;
 
 	private static final Cache cache = new Cache();
@@ -369,6 +370,17 @@ public class Value {
 	}
 
 	public Color getColor() {
+		if(AppPreferences.COLORBLIND_MODE.getBoolean()) {
+			WIDTH_ERROR_COLOR = new Color(196, 19, 219); // pink is new width error
+			UNKNOWN_COLOR = new Color(1, 188, 157); // green is new unknown
+			TRUE_COLOR = new Color(244, 235, 66); // yellow is new True
+			FALSE_COLOR = new Color(32, 59, 232); // blue is new False
+		} else {
+			WIDTH_ERROR_COLOR = new Color(255, 123, 0); 
+			UNKNOWN_COLOR = new Color(40, 40, 255); 
+			TRUE_COLOR = new Color(0, 210, 0); 
+			FALSE_COLOR = new Color(0, 100, 0); 
+		}
 		if (error != 0) {
 			return ERROR_COLOR;
 		} else if (width == 0) {

--- a/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/LayoutOptions.java
@@ -51,6 +51,8 @@ class LayoutOptions extends OptionsPanel {
 						Strings.getter("layoutAntiAliasing")),
 				new PrefBoolean(AppPreferences.PRINTER_VIEW,
 						Strings.getter("layoutPrinterView")),
+				new PrefBoolean(AppPreferences.COLORBLIND_MODE,
+						Strings.getter("layoutColorblindMode")),
 				new PrefBoolean(AppPreferences.ATTRIBUTE_HALO,
 						Strings.getter("layoutAttributeHalo")),
 				new PrefBoolean(AppPreferences.COMPONENT_TIPS,

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -517,6 +517,8 @@ public class AppPreferences {
 	public static final String ADD_AFTER_EDIT = "edit";
 	public static final PrefMonitor<Boolean> PRINTER_VIEW = create(new PrefMonitorBoolean(
 			"printerView", false));
+	public static final PrefMonitor<Boolean> COLORBLIND_MODE = create(new PrefMonitorBoolean(
+			"colorblindMode", false));
 	public static final PrefMonitor<Boolean> ATTRIBUTE_HALO = create(new PrefMonitorBoolean(
 			"attributeHalo", true));
 	public static final PrefMonitor<Boolean> COMPONENT_TIPS = create(new PrefMonitorBoolean(

--- a/src/main/resources/resources/logisim/en/prefs.properties
+++ b/src/main/resources/resources/logisim/en/prefs.properties
@@ -48,6 +48,7 @@ layoutNamedCircuitBoxes = Use pin labels on circuit boxes
 layoutNamedCircuitBoxesFixedSize = Use fixed size circuit boxes
 layoutUseNewInputOutputSymbols = Use new input and output shapes
 layoutPrinterView = Printer view
+layoutColorblindMode = Use colorblind color scheme
 layoutMoveKeepConnect = Keep connections while moving
 layoutAttributeHalo = Show attribute halo
 layoutShowTips = Show component tips


### PR DESCRIPTION
Added a blue/yellow based wire color scheme for red/green colorblind individuals who find the current color scheme unusable. The colors can be changed in preferences -> layout.