### PR TITLE
add octo line size to memory

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Mem.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Mem.java
@@ -101,8 +101,9 @@ public abstract class Mem extends InstanceFactory {
   public static final AttributeOption SINGLE = new AttributeOption("single",S.getter("memSingle"));
   public static final AttributeOption DUAL = new AttributeOption("dual",S.getter("memDual"));
   public static final AttributeOption QUAD = new AttributeOption("quad",S.getter("memQuad"));
+  public static final AttributeOption OCTO = new AttributeOption("octo",S.getter("memOcto"));
   public static final Attribute<AttributeOption> LINE_ATTR = Attributes.forOption("line", S.getter("memLineSize"),
-               new AttributeOption[] {SINGLE,DUAL,QUAD});
+               new AttributeOption[] {SINGLE,DUAL,QUAD,OCTO});
   static final AttributeOption WRITEAFTERREAD = new AttributeOption("war",S.getter("memWar"));
   static final AttributeOption READAFTERWRITE = new AttributeOption("raw",S.getter("memRaw"));
   static final Attribute<AttributeOption> READ_ATTR = Attributes.forOption("readbehav", S.getter("memReadBehav"), 

--- a/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
@@ -62,6 +62,7 @@ public class RamAppearance {
          attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES)) {
       if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.DUAL)) return 2;
       if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD)) return 4;
+      if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO)) return 8;
     }
     return 1;  
   }
@@ -89,6 +90,7 @@ public class RamAppearance {
     if (attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES)) {
       if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.DUAL)) return 2;
       if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD)) return 4;
+      if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO)) return 8;
     }
     return 0;
   }
@@ -315,6 +317,7 @@ public class RamAppearance {
       return 1;
     if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.DUAL)) return 2;
     if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD)) return 4;
+    if (attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO)) return 8;
     return 1;
   }
   private static int getDataOffset(int portOffset, int portIndex, AttributeSet attrs) {
@@ -327,7 +330,15 @@ public class RamAppearance {
       case 2  : 
       case 3  : if ((!attrs.containsAttribute(Mem.ENABLES_ATTR) ||
 		             attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES))&&
-                    attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD)) return portOffset+portIndex;
+                    (attrs.getValue(Mem.LINE_ATTR).equals(Mem.QUAD) ||
+                     attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO))) return portOffset+portIndex;
+                else return -1;
+      case 4  :
+      case 5  :
+      case 6  :
+      case 7  :  if ((!attrs.containsAttribute(Mem.ENABLES_ATTR) ||
+		             attrs.getValue(Mem.ENABLES_ATTR).equals(Mem.USELINEENABLES))&&
+		             attrs.getValue(Mem.LINE_ATTR).equals(Mem.OCTO)) return portOffset+portIndex;
                 else return -1;
       default : return -1;
     }

--- a/src/main/resources/resources/logisim/de/std.properties
+++ b/src/main/resources/resources/logisim/de/std.properties
@@ -444,6 +444,7 @@ memDual = Zweifach
 memEnables = Aktiviert:
 memLine = Zeilenfreigaben verwenden
 memLineSize = Größe der Linie
+memOcto = Octo
 memQuad = Quad
 memRaw = Lesen nach Schreiben
 memReadBehav = Leseverhalten

--- a/src/main/resources/resources/logisim/el/std.properties
+++ b/src/main/resources/resources/logisim/el/std.properties
@@ -443,7 +443,8 @@ jkFlipFlopComponent = J-K Flip-Flop
 # ==> memDual = 
 # ==> memEnables = 
 # ==> memLine = 
-# ==> memLineSize = 
+# ==> memLineSize =
+# ==> memOcto =
 # ==> memQuad = 
 # ==> memRaw = 
 # ==> memReadBehav = 

--- a/src/main/resources/resources/logisim/en/std.properties
+++ b/src/main/resources/resources/logisim/en/std.properties
@@ -444,6 +444,7 @@ memDual = Dual
 memEnables = Enables:
 memLine = Use line enables
 memLineSize = Line size
+memOcto = Octo
 memQuad = Quad
 memRaw = Read after write
 memReadBehav = Read behavior

--- a/src/main/resources/resources/logisim/es/std.properties
+++ b/src/main/resources/resources/logisim/es/std.properties
@@ -444,6 +444,7 @@ memDual = Doble
 memEnables = Habilita:
 memLine = La línea de uso permite
 memLineSize = Tamaño de la línea
+memOcto = Octo
 memQuad = Quad
 memRaw = Leer después de escribir
 memReadBehav = Leer el comportamiento

--- a/src/main/resources/resources/logisim/fr/std.properties
+++ b/src/main/resources/resources/logisim/fr/std.properties
@@ -444,6 +444,7 @@ memDual = Double
 memEnables = Activation :
 memLine = Par signal (Output Enable)
 memLineSize = Taille de la ligne
+memOcto = Octo
 memQuad = Quad
 memRaw = Lire après écrire
 memReadBehav = Comportement de lecture

--- a/src/main/resources/resources/logisim/it/std.properties
+++ b/src/main/resources/resources/logisim/it/std.properties
@@ -444,6 +444,7 @@ memDual = Doppio
 memEnables = Abilita:
 memLine = La linea di utilizzo consente
 memLineSize = Dimensione della linea
+memOcto = Octo
 memQuad = Quad
 memRaw = Leggere dopo scrivere
 memReadBehav = Leggere il comportamento

--- a/src/main/resources/resources/logisim/nl/std.properties
+++ b/src/main/resources/resources/logisim/nl/std.properties
@@ -444,6 +444,7 @@ memDual = Tweevoudig
 memEnables = Maakt het mogelijk:
 memLine = Gebruikslijn maakt het mogelijk
 memLineSize = Lijngrootte
+memOcto = Octo
 memQuad = Quad
 memRaw = Lezen na schrijven
 memReadBehav = Leesgedrag

--- a/src/main/resources/resources/logisim/pt/std.properties
+++ b/src/main/resources/resources/logisim/pt/std.properties
@@ -444,6 +444,7 @@ memDual = Duplo
 memEnables = Permite:
 memLine = A linha de uso permite
 memLineSize = Tamanho da linha
+memOcto = Octo
 memQuad = Quad
 memRaw = Ler depois de escrever
 memReadBehav = Comportamento de leitura

--- a/src/main/resources/resources/logisim/ru/std.properties
+++ b/src/main/resources/resources/logisim/ru/std.properties
@@ -444,6 +444,7 @@ memDual = Двойной
 memEnables = Позволяет:
 memLine = Линия использования позволяет
 memLineSize = Размер линии
+memOcto = Octo
 memQuad = Quad
 memRaw = Читать после записи
 memReadBehav = Поведение при чтении


### PR DESCRIPTION
Add octo line size to be able to simulate 64-bit byte-addressed memory.