### PR TITLE
attribute for allowing unaligned multi-line ram/rom accesses

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Mem.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Mem.java
@@ -103,6 +103,8 @@ public abstract class Mem extends InstanceFactory {
   public static final AttributeOption QUAD = new AttributeOption("quad",S.getter("memQuad"));
   public static final Attribute<AttributeOption> LINE_ATTR = Attributes.forOption("line", S.getter("memLineSize"),
                new AttributeOption[] {SINGLE,DUAL,QUAD});
+  public static final Attribute<Boolean> ALLOW_MISALIGNED =
+          Attributes.forBoolean("misaligned", S.getter("memMisaligned"));
   static final AttributeOption WRITEAFTERREAD = new AttributeOption("war",S.getter("memWar"));
   static final AttributeOption READAFTERWRITE = new AttributeOption("raw",S.getter("memRaw"));
   static final Attribute<AttributeOption> READ_ATTR = Attributes.forOption("readbehav", S.getter("memReadBehav"), 

--- a/src/main/java/com/cburch/logisim/std/memory/MemState.java
+++ b/src/main/java/com/cburch/logisim/std/memory/MemState.java
@@ -291,11 +291,7 @@ class MemState implements InstanceData, Cloneable, HexModelListener {
   }
   
   private boolean highLight(int addr, int nrItemsToHighlight) {
-	long mask = -1L;
-	mask *= nrItemsToHighlight;
-	long leftAddr = curAddr & mask;
-	long rightAddr = leftAddr+nrItemsToHighlight;
-	return (addr >= curAddr)&&(addr < rightAddr);
+	return (addr >= curAddr)&&(addr < curAddr+nrItemsToHighlight);
   }
   
   private Bounds getDataBound(int xoff, int yoff, int line, int column) {

--- a/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAttributes.java
@@ -73,6 +73,7 @@ public class RamAttributes extends AbstractAttributeSet {
   private AttributeOption RWBehavior = Mem.READAFTERWRITE;
   private Boolean ClearPin = false;
   private AttributeOption lineSize = Mem.SINGLE;
+  private Boolean allowMisaligned = false;
   private AttributeOption typeOfEnables = Mem.USEBYTEENABLES;
   private AttributeOption ramType = VOLATILE;
 
@@ -102,11 +103,14 @@ public class RamAttributes extends AbstractAttributeSet {
       } else changes |= myAttributes.contains(Mem.ASYNC_READ);
       newList.add(ATTR_DBUS);
       changes |= myAttributes.contains(Mem.LINE_ATTR);
+      changes |= myAttributes.contains(Mem.ALLOW_MISALIGNED);
     } else {
       newList.add(Mem.LINE_ATTR);
+      newList.add(Mem.ALLOW_MISALIGNED);
       newList.add(StdAttr.TRIGGER);
       newList.add(ATTR_DBUS);
-      changes = !myAttributes.contains(Mem.LINE_ATTR);
+      changes |= !myAttributes.contains(Mem.LINE_ATTR);
+      changes |= !myAttributes.contains(Mem.ALLOW_MISALIGNED);
     }
     newList.add(StdAttr.LABEL);
     newList.add(StdAttr.LABEL_FONT);
@@ -133,6 +137,7 @@ public class RamAttributes extends AbstractAttributeSet {
     d.RWBehavior = RWBehavior;
     d.ClearPin = ClearPin;
     d.lineSize = lineSize;
+    d.allowMisaligned = allowMisaligned;
     d.typeOfEnables = typeOfEnables;
     d.ramType = ramType;
   }
@@ -183,6 +188,9 @@ public class RamAttributes extends AbstractAttributeSet {
     }
     if (attr == Mem.LINE_ATTR) {
       return (V) lineSize;
+    }
+    if (attr == Mem.ALLOW_MISALIGNED) {
+      return (V) allowMisaligned;
     }
     if (attr == CLEAR_PIN) {
       return (V) ClearPin;
@@ -294,6 +302,12 @@ public class RamAttributes extends AbstractAttributeSet {
       AttributeOption val = (AttributeOption) value;
       if (!lineSize.equals(val)) {
         lineSize = val;
+        fireAttributeValueChanged(attr, value, null);
+      }
+    } else if (attr == Mem.ALLOW_MISALIGNED) {
+      Boolean val = (Boolean) value;
+      if (allowMisaligned != val) {
+        allowMisaligned = val;
         fireAttributeValueChanged(attr, value, null);
       }
     } else if (attr == StdAttr.APPEARANCE) {

--- a/src/main/java/com/cburch/logisim/std/memory/Rom.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Rom.java
@@ -286,11 +286,12 @@ public class Rom extends Mem {
     }
     
     boolean misaligned = addr%nrDataLines != 0; 
-    
+    boolean misalignError = misaligned && !state.getAttributeValue(ALLOW_MISALIGNED);
+
     for (int i = 0 ; i < nrDataLines ; i++) {
       long val = myState.getContents().get(addr+i);
-      state.setPort(RamAppearance.getDataOutIndex(i, attrs), 
-                    misaligned ? Value.createError(dataBits) : Value.createKnown(dataBits, val), DELAY);
+      state.setPort(RamAppearance.getDataOutIndex(i, attrs),
+              misalignError ? Value.createError(dataBits) : Value.createKnown(dataBits, val), DELAY);
     }
   }
 

--- a/src/main/java/com/cburch/logisim/std/memory/RomAttributes.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RomAttributes.java
@@ -78,6 +78,7 @@ class RomAttributes extends AbstractAttributeSet {
             Mem.ADDR_ATTR,
             Mem.DATA_ATTR,
             Mem.LINE_ATTR,
+            Mem.ALLOW_MISALIGNED,
             Rom.CONTENTS_ATTR,
             StdAttr.LABEL,
             StdAttr.LABEL_FONT,
@@ -94,6 +95,7 @@ class RomAttributes extends AbstractAttributeSet {
   private BitWidth dataBits = BitWidth.create(8);
   private MemContents contents;
   private AttributeOption lineSize = Mem.SINGLE;
+  private Boolean allowMisaligned = false;
   private String Label = "";
   private Font LabelFont = StdAttr.DEFAULT_LABEL_FONT;
   private Boolean LabelVisable = false;
@@ -109,6 +111,7 @@ class RomAttributes extends AbstractAttributeSet {
     d.addrBits = addrBits;
     d.dataBits = dataBits;
     d.lineSize = lineSize;
+    d.allowMisaligned = allowMisaligned;
     d.contents = contents.clone();
     d.LabelFont = LabelFont;
     d.LabelVisable = LabelVisable;
@@ -131,6 +134,9 @@ class RomAttributes extends AbstractAttributeSet {
     }
     if (attr == Mem.LINE_ATTR) {
       return (V) lineSize;
+    }
+    if (attr == Mem.ALLOW_MISALIGNED) {
+      return (V) allowMisaligned;
     }
     if (attr == Rom.CONTENTS_ATTR) {
       return (V) contents;
@@ -172,6 +178,11 @@ class RomAttributes extends AbstractAttributeSet {
       AttributeOption val = (AttributeOption) value;
       if (lineSize.equals(val)) return;
       lineSize = val;
+      fireAttributeValueChanged(attr, value, null);
+    } else if (attr == Mem.ALLOW_MISALIGNED) {
+      Boolean val = (Boolean) value;
+      if (allowMisaligned.equals(val)) return;
+      allowMisaligned = val;
       fireAttributeValueChanged(attr, value, null);
     } else if (attr == Rom.CONTENTS_ATTR) {
       MemContents newContents = (MemContents) value;

--- a/src/main/resources/resources/logisim/en/std.properties
+++ b/src/main/resources/resources/logisim/en/std.properties
@@ -444,6 +444,7 @@ memDual = Dual
 memEnables = Enables:
 memLine = Use line enables
 memLineSize = Line size
+memMisaligned = Allow misaligned?
 memQuad = Quad
 memRaw = Read after write
 memReadBehav = Read behavior


### PR DESCRIPTION
I don't know if "Use line enables" option is here to stay, but currently under this option, any unaligned access will set all the outputs as errors.

In real hardware, you might need some extra read/write ports and shift and mask or something, but this attribute can simplify the circuit by assuming all of that is conveniently implemented within the RAM/ROM block. 