### PR TITLE
fix load memory contents from file

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/MemContents.java
+++ b/src/main/java/com/cburch/logisim/std/memory/MemContents.java
@@ -363,7 +363,7 @@ public class MemContents implements Cloneable, HexModel {
     count = (int)Math.min(count, getLastOffset() - start + 1);
     if (count <= 0)
       return;
-    if (src.addrBits != width)
+    if (src.addrBits != addrBits)
       throw new IllegalArgumentException(String.format(
               "memory width mismatch: src is %d bits wide, dest is %d bits wide",
               src.addrBits, addrBits));


### PR DESCRIPTION
Looking at the logs, it looks like this bug (?) came back again during a merge. I'm not sure what this check is doing, but I was seeing in the log:
> "memory width mismatch: src is 24 bits wide, dest is 24 bits wide"