### PR TITLE
Fix redo accelerator key to be cmd-shift-Z

### DIFF
--- a/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -104,7 +104,7 @@ class MenuEdit extends Menu {
 
     int menuMask = getToolkit().getMenuShortcutKeyMask();
     undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask));
-    redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, menuMask));
+    redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask | KeyEvent.SHIFT_DOWN_MASK));
     cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, menuMask));
     copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, menuMask));
     paste.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, menuMask));


### PR DESCRIPTION
This PR fixes the accelerator key for Redo to be cmd-shift-Z as requested in #386. The conflict noted there with Reset Simulator should exist on all platforms and this PR should fix all of them to the customary cmd-shift-Z or ctrl-shift-Z.