### PR TITLE
Small fix on English docs translation

### DIFF
--- a/src/main/resources/doc/en/html/guide/analyze/ana-open.html
+++ b/src/main/resources/doc/en/html/guide/analyze/ana-open.html
@@ -32,7 +32,7 @@
         Via the Project menu
       </h2>
       <p>
-        From a window for editing circuits, you can also request that Logisim analyze the current circuit by selecting the Analyze Circuit option from the menu <b class=menu>|&nbsp;Project&nbsp;|</b>→<b class=menu>|&nbsp;Analyse combinatoire&nbsp;|</b>. Before Logisim opens the window, it will compute Boolean expressions and a truth table corresponding to the circuit and place them there for you to view.
+        From a window for editing circuits, you can also request that Logisim analyze the current circuit by selecting the Analyze Circuit option from the menu <b class=menu>|&nbsp;Project&nbsp;|</b>→<b class=menu>|&nbsp;Analyze Circuit&nbsp;|</b>. Before Logisim opens the window, it will compute Boolean expressions and a truth table corresponding to the circuit and place them there for you to view.
       </p>
       <p>
         For the analysis to be successful, each input must be attached to an input pin, and each output must be attached to an output pin. Logisim will only analyze circuits with at most <b>eight</b> of each type, and all should be single-bit pins. Otherwise, you will see an error message and the window will not open.


### PR DESCRIPTION
Caught a missing translation: "| Project |→| Analyse combinatoire |". Replaced French localization "Analyse combinatoire" with counterpart in the English localization, "Analyze Circuit".