### PR TITLE
Fix German translation

### DIFF
--- a/src/main/resources/resources/logisim/de/std.properties
+++ b/src/main/resources/resources/logisim/de/std.properties
@@ -253,7 +253,7 @@ Hz = Hz
 #
 BorderColor = Randfarbe
 bothOption = beide
-ClearDiagram = Übersichtliches Diagramm
+ClearDiagram = Diagramm leeren
 DigitalOscilloscopeClock = Uhr
 DrawClockFrontLine = Uhr an der Frontlinie zeichnen
 noOption = keine


### PR DESCRIPTION
Clear Diagram was translated as "clearly represented diagram" in German. This PR fixes that.