### PR TITLE
Use more accurate clock and unified memory components design

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/Simulator.java
+++ b/src/main/java/com/cburch/logisim/circuit/Simulator.java
@@ -312,20 +312,20 @@ public class Simulator {
     }
   }
 
-  //TODO: convert half-cycle frequency to full-cycle frequency
+  // TODO: convert half-cycle frequency to full-cycle frequency
   public void setTickFrequency(double freq) {
     if (tickFrequency != freq) {
-      int millis = (int) Math.round(1000 / freq);
+      long nanos = (long) Math.round(1e9 / freq);
       int ticks;
-      if (millis > 0) {
+      if (nanos > 0) {
         ticks = 1;
       } else {
-        millis = 1;
-        ticks = (int) Math.round(freq / 1000);
+        nanos = 1;
+        ticks = (int) Math.round(freq / 1e9);
       }
 
       tickFrequency = freq;
-      ticker.setTickFrequency(millis, ticks);
+      ticker.setTickFrequency(nanos, ticks);
       renewTickerAwake();
       fireSimulatorStateChanged();
     }

--- a/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
@@ -126,10 +126,10 @@ public class ComponentDrawContext {
   }
 
   public void drawClockSymbol(Component comp, int xpos, int ypos) {
-	  GraphicsUtil.switchToWidth(g, 2);
-	int[] xcoords = {xpos + 1, xpos + 8, xpos + 1};
-	int[] ycoords = {ypos - 4, ypos, ypos + 4};
-	g.drawPolyline(xcoords, ycoords, 3);
+    GraphicsUtil.switchToWidth(g, 2);
+    int[] xcoords = {xpos + 1, xpos + 8, xpos + 1};
+    int[] ycoords = {ypos - 4, ypos, ypos + 4};
+    g.drawPolyline(xcoords, ycoords, 3);
     GraphicsUtil.switchToWidth(g, 1);
   }
 

--- a/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
+++ b/src/main/java/com/cburch/logisim/comp/ComponentDrawContext.java
@@ -126,9 +126,10 @@ public class ComponentDrawContext {
   }
 
   public void drawClockSymbol(Component comp, int xpos, int ypos) {
-    GraphicsUtil.switchToWidth(g, 2);
-    g.drawLine(xpos, ypos - 4, xpos + 8, ypos);
-    g.drawLine(xpos, ypos + 4, xpos + 8, ypos);
+	  GraphicsUtil.switchToWidth(g, 2);
+	int[] xcoords = {xpos + 1, xpos + 8, xpos + 1};
+	int[] ycoords = {ypos - 4, ypos, ypos + 4};
+	g.drawPolyline(xcoords, ycoords, 3);
     GraphicsUtil.switchToWidth(g, 1);
   }
 

--- a/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
@@ -328,15 +328,19 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     Location loc = painter.getLocation();
     int x = loc.getX();
     int y = loc.getY();
+    
+    // Draw outer rectangle
     GraphicsUtil.switchToWidth(g, 2);
     g.drawRect(x, y, 40, 60);
+    
+    // Draw info circle
     if (painter.getShowState()) {
       StateData myState = (StateData) painter.getData();
       if (myState != null) {
         g.setColor(myState.curValue.getColor());
         g.fillOval(x + 13, y + 23, 14, 14);
         g.setColor(Color.WHITE);
-        GraphicsUtil.drawCenteredText(g, myState.curValue.toDisplayString(), x + 19, y + 28);
+        GraphicsUtil.drawCenteredText(g, myState.curValue.toDisplayString(), x + 20, y + 28);
         g.setColor(Color.BLACK);
       }
     }
@@ -346,39 +350,44 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     painter.drawPort(n + 3, "R", Direction.SOUTH);
     painter.drawPort(n + 4, "S", Direction.NORTH);
     g.setColor(Color.BLACK);
+    
+    // Draw input ports (J/K, S/R, D, T)
     for (int i = 0; i < n; i++) {
-      GraphicsUtil.switchToWidth(g, 2);
+      GraphicsUtil.switchToWidth(g, GraphicsUtil.DATA_SINGLE_WIDTH);
       g.drawLine(x - 10, y + 10 + i * 20, x - 1, y + 10 + i * 20);
-      GraphicsUtil.switchToWidth(g, 1);
       painter.drawPort(i);
       GraphicsUtil.drawCenteredText(g, getInputName(i), x + 8, y + 8 + i * 20);
     }
+
     Object Trigger = painter.getAttributeValue(triggerAttribute);
+    // Draw clock or enable symbol
     if (Trigger.equals(StdAttr.TRIG_RISING) || Trigger.equals(StdAttr.TRIG_FALLING)) {
       painter.drawClockSymbol(x, y + 50);
     } else {
       GraphicsUtil.drawCenteredText(g, "E", x + 8, y + 48);
     }
+    
+    // Draw regular/negated input
     if (Trigger.equals(StdAttr.TRIG_RISING) || Trigger.equals(StdAttr.TRIG_HIGH)) {
-      GraphicsUtil.switchToWidth(g, 2);
+      GraphicsUtil.switchToWidth(g, GraphicsUtil.CONTROL_WIDTH);
       g.drawLine(x - 10, y + 50, x - 1, y + 50);
-      GraphicsUtil.switchToWidth(g, 1);
     } else {
-      GraphicsUtil.switchToWidth(g, 2);
+      GraphicsUtil.switchToWidth(g, GraphicsUtil.NEGATED_WIDTH);
       g.drawOval(x - 10, y + 45, 10, 10);
-      GraphicsUtil.switchToWidth(g, 1);
     }
     painter.drawPort(n);
 
-    GraphicsUtil.switchToWidth(g, 2);
+    // Draw output ports
+    GraphicsUtil.switchToWidth(g, GraphicsUtil.DATA_SINGLE_WIDTH);
     g.drawLine(x + 41, y + 10, x + 50, y + 10);
-    GraphicsUtil.switchToWidth(g, 1);
     GraphicsUtil.drawCenteredText(g, "Q", x + 31, y + 8);
     painter.drawPort(n + 1);
-    GraphicsUtil.switchToWidth(g, 2);
+    GraphicsUtil.switchToWidth(g, GraphicsUtil.NEGATED_WIDTH);
     g.drawOval(x + 40, y + 45, 10, 10);
-    GraphicsUtil.switchToWidth(g, 1);
     painter.drawPort(n + 2);
+
+    // Reset width
+    GraphicsUtil.switchToWidth(g, 1);
   }
 
   @Override

--- a/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
@@ -334,7 +334,7 @@ abstract class AbstractFlipFlop extends InstanceFactory {
         g.setColor(myState.curValue.getColor());
         g.fillOval(x + 13, y + 23, 14, 14);
         g.setColor(Color.WHITE);
-        GraphicsUtil.drawCenteredText(g, myState.curValue.toDisplayString(), x + 21, y + 29);
+        GraphicsUtil.drawCenteredText(g, myState.curValue.toDisplayString(), x + 19, y + 28);
         g.setColor(Color.BLACK);
       }
     }
@@ -345,18 +345,22 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     painter.drawPort(n + 4, "S", Direction.NORTH);
     g.setColor(Color.BLACK);
     for (int i = 0; i < n; i++) {
-      g.fillRect(x - 10, y + 9 + i * 20, 10, 3);
+        GraphicsUtil.switchToWidth(g, 2);
+        g.drawLine(x - 10, y + 10 + i * 20, x - 1, y + 10 + i * 20);
+        GraphicsUtil.switchToWidth(g, 1);
       painter.drawPort(i);
-      GraphicsUtil.drawCenteredText(g, getInputName(i), x + 8, y + 10 + i * 20);
+      GraphicsUtil.drawCenteredText(g, getInputName(i), x + 8, y + 8 + i * 20);
     }
     Object Trigger = painter.getAttributeValue(triggerAttribute);
     if (Trigger.equals(StdAttr.TRIG_RISING) || Trigger.equals(StdAttr.TRIG_FALLING)) {
       painter.drawClockSymbol(x, y + 50);
     } else {
-      GraphicsUtil.drawCenteredText(g, "E", x + 8, y + 50);
+      GraphicsUtil.drawCenteredText(g, "E", x + 8, y + 48);
     }
     if (Trigger.equals(StdAttr.TRIG_RISING) || Trigger.equals(StdAttr.TRIG_HIGH)) {
-      g.fillRect(x - 10, y + 49, 10, 3);
+      GraphicsUtil.switchToWidth(g, 2);
+      g.drawLine(x - 10, y + 50, x - 1, y + 50);
+      GraphicsUtil.switchToWidth(g, 1);
     } else {
       GraphicsUtil.switchToWidth(g, 2);
       g.drawOval(x - 10, y + 45, 10, 10);
@@ -364,8 +368,10 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     }
     painter.drawPort(n);
 
-    g.fillRect(x + 40, y + 9, 10, 3);
-    GraphicsUtil.drawCenteredText(g, "Q", x + 31, y + 10);
+    GraphicsUtil.switchToWidth(g, 2);
+    g.drawLine(x + 41, y + 10, x + 50, y + 10);
+    GraphicsUtil.switchToWidth(g, 1);
+    GraphicsUtil.drawCenteredText(g, "Q", x + 31, y + 8);
     painter.drawPort(n + 1);
     GraphicsUtil.switchToWidth(g, 2);
     g.drawOval(x + 40, y + 45, 10, 10);

--- a/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
+++ b/src/main/java/com/cburch/logisim/std/memory/AbstractFlipFlop.java
@@ -146,7 +146,8 @@ abstract class AbstractFlipFlop extends InstanceFactory {
 
   private Attribute<AttributeOption> triggerAttribute;
 
-  protected AbstractFlipFlop(String name, String iconName, StringGetter desc, int numInputs, boolean allowLevelTriggers) {
+  protected AbstractFlipFlop(
+      String name, String iconName, StringGetter desc, int numInputs, boolean allowLevelTriggers) {
     super(name, desc);
     this.numInputs = numInputs;
     setIconName(iconName);
@@ -160,19 +161,20 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     setInstanceLogger(Logger.class);
   }
 
-  protected AbstractFlipFlop(String name, Icon icon, StringGetter desc, int numInputs, boolean allowLevelTriggers) {
-	    super(name, desc);
-	    this.numInputs = numInputs;
-	    setIcon(icon);
-	    triggerAttribute = allowLevelTriggers ? StdAttr.TRIGGER : StdAttr.EDGE_TRIGGER;
-	    setAttributes(
-	        new Attribute[] {triggerAttribute, StdAttr.LABEL, StdAttr.LABEL_FONT, StdAttr.APPEARANCE},
-	        new Object[] {
-	          StdAttr.TRIG_RISING, "", StdAttr.DEFAULT_LABEL_FONT, AppPreferences.getDefaultAppearance()
-	        });
-	    setInstancePoker(Poker.class);
-	    setInstanceLogger(Logger.class);
-	  }
+  protected AbstractFlipFlop(
+      String name, Icon icon, StringGetter desc, int numInputs, boolean allowLevelTriggers) {
+    super(name, desc);
+    this.numInputs = numInputs;
+    setIcon(icon);
+    triggerAttribute = allowLevelTriggers ? StdAttr.TRIGGER : StdAttr.EDGE_TRIGGER;
+    setAttributes(
+        new Attribute[] {triggerAttribute, StdAttr.LABEL, StdAttr.LABEL_FONT, StdAttr.APPEARANCE},
+        new Object[] {
+          StdAttr.TRIG_RISING, "", StdAttr.DEFAULT_LABEL_FONT, AppPreferences.getDefaultAppearance()
+        });
+    setInstancePoker(Poker.class);
+    setInstanceLogger(Logger.class);
+  }
 
   private void updatePorts(Instance instance) {
     Port[] ps = new Port[numInputs + STD_PORTS];
@@ -345,9 +347,9 @@ abstract class AbstractFlipFlop extends InstanceFactory {
     painter.drawPort(n + 4, "S", Direction.NORTH);
     g.setColor(Color.BLACK);
     for (int i = 0; i < n; i++) {
-        GraphicsUtil.switchToWidth(g, 2);
-        g.drawLine(x - 10, y + 10 + i * 20, x - 1, y + 10 + i * 20);
-        GraphicsUtil.switchToWidth(g, 1);
+      GraphicsUtil.switchToWidth(g, 2);
+      g.drawLine(x - 10, y + 10 + i * 20, x - 1, y + 10 + i * 20);
+      GraphicsUtil.switchToWidth(g, 1);
       painter.drawPort(i);
       GraphicsUtil.drawCenteredText(g, getInputName(i), x + 8, y + 8 + i * 20);
     }

--- a/src/main/java/com/cburch/logisim/std/memory/Counter.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Counter.java
@@ -184,16 +184,19 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     GraphicsUtil.switchToWidth(g, 2);
     BitWidth widthVal = painter.getAttributeValue(StdAttr.WIDTH);
     int width = widthVal == null ? 8 : widthVal.getWidth();
-    g.drawLine(xpos + 20, ypos, xpos + 20 + SymbolWidth(width), ypos);
-    g.drawLine(xpos + 20, ypos, xpos + 20, ypos + 100);
-    g.drawLine(xpos + 20 + SymbolWidth(width), ypos, xpos + 20 + SymbolWidth(width), ypos + 100);
-    g.drawLine(xpos + 20, ypos + 100, xpos + 30, ypos + 100);
-    g.drawLine(
-        xpos + 10 + SymbolWidth(width), ypos + 100, xpos + 20 + SymbolWidth(width), ypos + 100);
-    g.drawLine(xpos + 30, ypos + 100, xpos + 30, ypos + 110);
-    g.drawLine(
-        xpos + 10 + SymbolWidth(width), ypos + 100, xpos + 10 + SymbolWidth(width), ypos + 110);
-    /* Draw clock entry symbols */
+    int symbolWidth = SymbolWidth(width);
+    // Draw top
+    int[] controlTopx = new int[8];
+    controlTopx[0] = controlTopx[1] = xpos + 30;
+    controlTopx[2] = controlTopx[3] = xpos + 20;
+    controlTopx[4] = controlTopx[5] = xpos + 20 + symbolWidth;
+    controlTopx[6] = controlTopx[7] = xpos + 10 + symbolWidth;
+    int[] controlTopy = new int[8];
+    controlTopy[0] = controlTopy[7] = ypos + 110;
+    controlTopy[1] = controlTopy[2] = controlTopy[5] = controlTopy[6] = ypos + 100;
+    controlTopy[3] = controlTopy[4] = ypos;
+    g.drawPolyline(controlTopx, controlTopy, controlTopx.length);
+    // These are up here because they reset the width to 1 when done.
     painter.drawClockSymbol(xpos + 20, ypos + 80);
     painter.drawClockSymbol(xpos + 20, ypos + 90);
     /* Draw Label */
@@ -206,7 +209,7 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
             ? "CTR" + Integer.toString(painter.getAttributeValue(StdAttr.WIDTH).getWidth())
             : "CTR DIV0x" + Long.toHexString(max);
     GraphicsUtil.drawCenteredText(g, Label, xpos + (SymbolWidth(width) / 2) + 20, ypos + 5);
-    GraphicsUtil.switchToWidth(g, 2);
+    GraphicsUtil.switchToWidth(g, GraphicsUtil.CONTROL_WIDTH);
     /* Draw Reset Input */
     g.drawLine(xpos, ypos + 20, xpos + 20, ypos + 20);
     GraphicsUtil.drawText(g, "R", xpos + 30, ypos + 20, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
@@ -280,7 +283,6 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
         GraphicsUtil.H_RIGHT,
         GraphicsUtil.V_CENTER);
     painter.drawPort(CARRY);
-    GraphicsUtil.switchToWidth(g, 1);
     /* Draw counter Value */
     RegisterData state = (RegisterData) painter.getData();
     if (painter.getShowState() && (state != null)) {
@@ -362,7 +364,7 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     g.setFont(font);
     GraphicsUtil.drawText(
         g, "1,6D", xpos + 21, RealYpos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
-    int LineWidth = (NrOfBits == 1) ? 2 : 5;
+    int LineWidth = (NrOfBits == 1) ? GraphicsUtil.DATA_SINGLE_WIDTH : GraphicsUtil.DATA_MULTI_WIDTH;
     GraphicsUtil.switchToWidth(g, LineWidth);
     if (first) {
       painter.drawPort(IN);

--- a/src/main/java/com/cburch/logisim/std/memory/Counter.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Counter.java
@@ -322,30 +322,26 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
     g.drawRect(xpos + 20, RealYpos, SymbolWidth(NrOfBits), 20);
     /* Input Line */
     if (NrOfBits > 1) {
-      g.drawLine(xpos + 10, RealYpos + 10, xpos + 20, RealYpos + 10);
-      g.drawLine(xpos + 5, RealYpos + 5, xpos + 10, RealYpos + 10);
+    	// Input Line
+    	int[] ixPoints = {xpos + 5, xpos + 10, xpos + 20};
+    	int[] iyPoints = {RealYpos + 5, RealYpos + 10, RealYpos + 10};
+    	g.drawPolyline(ixPoints, iyPoints, 3);
+    	
+    	// Output Line
+    	int[] oxPoints = {xpos + 20 + SymbolWidth(NrOfBits), xpos + 30 + SymbolWidth(NrOfBits), xpos + 35 + SymbolWidth(NrOfBits)};
+    	int[] oyPoints = {RealYpos + 10, RealYpos + 10, RealYpos + 5};
+    	g.drawPolyline(oxPoints, oyPoints, 3);
     } else {
+    	// Input Line
       g.drawLine(xpos, RealYpos + 10, xpos + 20, RealYpos + 10);
-    }
-    /* Ouput Line */
-    if (NrOfBits > 1) {
-      g.drawLine(
-          xpos + 20 + SymbolWidth(NrOfBits),
-          RealYpos + 10,
-          xpos + 30 + SymbolWidth(NrOfBits),
-          RealYpos + 10);
-      g.drawLine(
-          xpos + 30 + SymbolWidth(NrOfBits),
-          RealYpos + 10,
-          xpos + 35 + SymbolWidth(NrOfBits),
-          RealYpos + 5);
-    } else {
+      // Output Line
       g.drawLine(
           xpos + 20 + SymbolWidth(NrOfBits),
           RealYpos + 10,
           xpos + 40 + SymbolWidth(NrOfBits),
           RealYpos + 10);
     }
+    
     g.setColor(Color.BLACK);
     if (NrOfBits > 1) {
       GraphicsUtil.drawText(
@@ -372,18 +368,15 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
       painter.drawPort(IN);
       painter.drawPort(OUT);
       if (NrOfBits > 1) {
-        g.drawLine(xpos, RealYpos, xpos + 5, RealYpos + 5);
-        g.drawLine(
-            xpos + 35 + SymbolWidth(NrOfBits),
-            RealYpos + 5,
-            xpos + 40 + SymbolWidth(NrOfBits),
-            RealYpos);
-        g.drawLine(xpos + 5, RealYpos + 5, xpos + 5, RealYpos + 20);
-        g.drawLine(
-            xpos + 35 + SymbolWidth(NrOfBits),
-            RealYpos + 5,
-            xpos + 35 + SymbolWidth(NrOfBits),
-            RealYpos + 20);
+    	  // Input Line
+      	int[] ixPoints = {xpos, xpos + 5, xpos + 5};
+      	int[] iyPoints = {RealYpos, RealYpos + 5, RealYpos + 20};
+      	g.drawPolyline(ixPoints, iyPoints, 3);
+      	
+      	// Output Line
+      	int[] oxPoints = {xpos + 35 + SymbolWidth(NrOfBits), xpos + 35 + SymbolWidth(NrOfBits), xpos + 40 + SymbolWidth(NrOfBits)};
+      	int[] oyPoints = {RealYpos + 20, RealYpos + 5, RealYpos};
+      	g.drawPolyline(oxPoints, oyPoints, 3);
       }
     } else if (last) {
       g.drawLine(xpos + 5, RealYpos, xpos + 5, RealYpos + 5);

--- a/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
+++ b/src/main/java/com/cburch/logisim/std/memory/RamAppearance.java
@@ -736,7 +736,7 @@ public class RamAppearance {
     ypos[0] = ypos[7] = y+getControlHeight(attrs);
     ypos[1] = ypos[2] = ypos[5] = ypos[6] = ypos[0]-10;
     ypos[3] = ypos[4] = y;
-    g.setStroke(new BasicStroke(2));
+    GraphicsUtil.switchToWidth(g, 2);
     g.drawPolyline(xpos, ypos, 8);
     for (int i = 0 ; i < getNrAddrPorts(attrs) ; i++) {
       int idx = getAddrIndex(i,attrs);

--- a/src/main/java/com/cburch/logisim/std/memory/Register.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Register.java
@@ -80,7 +80,7 @@ public class Register extends InstanceFactory implements DynamicElementProvider 
       boolean neg_active,
       boolean has_we,
       Value value) {
-    int dq_width = (nr_of_bits == 1) ? 3 : 5;
+    int dq_width = (nr_of_bits == 1) ? 2 : 5;
     int len = (nr_of_bits + 3) / 4;
     int wid = 8 * len + 2;
     int xoff = (60 - wid) / 2;
@@ -119,31 +119,28 @@ public class Register extends InstanceFactory implements DynamicElementProvider 
     g.drawLine(x, y + 30, x + 8, y + 30);
     g.drawLine(x + 52, y + 30, x + 60, y + 30);
     GraphicsUtil.switchToWidth(g, 1);
-    GraphicsUtil.drawCenteredText(g, "D", x + 18, y + 30);
-    GraphicsUtil.drawCenteredText(g, "Q", x + 41, y + 30);
-    GraphicsUtil.switchToWidth(g, 3);
+    GraphicsUtil.drawCenteredText(g, "D", x + 18, y + 28);
+    GraphicsUtil.drawCenteredText(g, "Q", x + 41, y + 28);
+    GraphicsUtil.switchToWidth(g, 2);
     g.drawLine(x + 30, y + 81, x + 30, y + 90);
     GraphicsUtil.switchToWidth(g, 1);
     g.setColor(Color.GRAY);
-    GraphicsUtil.drawCenteredText(g, "R", x + 30, y + 70);
+    GraphicsUtil.drawCenteredText(g, "R", x + 30, y + 68);
     g.setColor(Color.BLACK);
     if (has_we) {
-      GraphicsUtil.drawCenteredText(g, "WE", x + 22, y + 50);
-      GraphicsUtil.switchToWidth(g, 3);
-      g.drawLine(x, y + 50, x + 10, y + 50);
+      GraphicsUtil.drawCenteredText(g, "WE", x + 22, y + 48);
+      GraphicsUtil.switchToWidth(g, 2);
+      g.drawLine(x, y + 50, x + 9, y + 50);
       GraphicsUtil.switchToWidth(g, 1);
     }
     if (!isLatch) {
-      GraphicsUtil.switchToWidth(g, 2);
-      g.drawLine(x + 10, y + 65, x + 20, y + 70);
-      g.drawLine(x + 10, y + 75, x + 20, y + 70);
-      GraphicsUtil.switchToWidth(g, 1);
+    	painter.drawClockSymbol(x + 10, y + 70);
     } else {
-      GraphicsUtil.drawCenteredText(g, "E", x + 18, y + 70);
+      GraphicsUtil.drawCenteredText(g, "E", x + 18, y + 68);
     }
     if (!neg_active) {
-      GraphicsUtil.switchToWidth(g, 3);
-      g.drawLine(x, y + 70, x + 10, y + 70);
+      GraphicsUtil.switchToWidth(g, 2);
+      g.drawLine(x, y + 70, x + 9, y + 70);
       GraphicsUtil.switchToWidth(g, 1);
     } else {
       GraphicsUtil.switchToWidth(g, 2);

--- a/src/main/java/com/cburch/logisim/std/memory/Register.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Register.java
@@ -134,7 +134,7 @@ public class Register extends InstanceFactory implements DynamicElementProvider 
       GraphicsUtil.switchToWidth(g, 1);
     }
     if (!isLatch) {
-    	painter.drawClockSymbol(x + 10, y + 70);
+      painter.drawClockSymbol(x + 10, y + 70);
     } else {
       GraphicsUtil.drawCenteredText(g, "E", x + 18, y + 68);
     }

--- a/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
@@ -316,7 +316,10 @@ public class ShiftRegister extends InstanceFactory {
     if (LastBlock) {
       GraphicsUtil.switchToWidth(g, DataWidth);
       g.drawLine(
-          real_xpos + blockwidth + line_fix, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
+          real_xpos + blockwidth + line_fix,
+          real_ypos + 10,
+          real_xpos + blockwidth + 10,
+          real_ypos + 10);
       painter.drawPort(OUT);
       GraphicsUtil.switchToWidth(g, 1);
     }
@@ -324,10 +327,16 @@ public class ShiftRegister extends InstanceFactory {
       GraphicsUtil.switchToWidth(g, DataWidth);
       if (current_stage == 0)
         g.drawLine(
-            real_xpos + blockwidth + line_fix, real_ypos + 20, real_xpos + blockwidth + 10, real_ypos + 20);
+            real_xpos + blockwidth + line_fix,
+            real_ypos + 20,
+            real_xpos + blockwidth + 10,
+            real_ypos + 20);
       else
         g.drawLine(
-            real_xpos + blockwidth + line_fix, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
+            real_xpos + blockwidth + line_fix,
+            real_ypos + 10,
+            real_xpos + blockwidth + 10,
+            real_ypos + 10);
       painter.drawPort(6 + 2 * current_stage + 1);
       GraphicsUtil.switchToWidth(g, 1);
     }

--- a/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
+++ b/src/main/java/com/cburch/logisim/std/memory/ShiftRegister.java
@@ -245,7 +245,8 @@ public class ShiftRegister extends InstanceFactory {
     int real_ypos = ypos + 70 + current_stage * 20;
     if (current_stage > 0) real_ypos += 10;
     int real_xpos = xpos + 10;
-    int DataWidth = (nr_of_bits == 1) ? 3 : 5;
+    int DataWidth = (nr_of_bits == 1) ? 2 : 5;
+    int line_fix = (nr_of_bits == 1) ? 1 : 2;
     int height = (current_stage == 0) ? 30 : 20;
     boolean LastBlock = (current_stage == (nr_of_stages - 1));
     int blockwidth = SymbolWidth;
@@ -292,14 +293,13 @@ public class ShiftRegister extends InstanceFactory {
     /* Draw the Inputs */
     if (current_stage == 0 || has_load) {
       GraphicsUtil.switchToWidth(g, DataWidth);
-      g.drawLine(real_xpos - 10, real_ypos + 10, real_xpos - 1, real_ypos + 10);
-      if (has_load) painter.drawPort(6 + 2 * current_stage);
+      g.drawLine(real_xpos - 10, real_ypos + 10, real_xpos - line_fix, real_ypos + 10);
       if (current_stage == 0) {
         painter.drawPort(IN);
         GraphicsUtil.drawText(
             g, "1,3D", real_xpos + 1, real_ypos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
         if (has_load) {
-          g.drawLine(real_xpos - 10, real_ypos + 20, real_xpos - 1, real_ypos + 20);
+          g.drawLine(real_xpos - 10, real_ypos + 20, real_xpos - line_fix, real_ypos + 20);
           GraphicsUtil.drawText(
               g, "2,3D", real_xpos + 1, real_ypos + 20, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
         }
@@ -307,6 +307,8 @@ public class ShiftRegister extends InstanceFactory {
         GraphicsUtil.drawText(
             g, "2,3D", real_xpos + 1, real_ypos + 10, GraphicsUtil.H_LEFT, GraphicsUtil.V_CENTER);
       }
+
+      if (has_load) painter.drawPort(6 + 2 * current_stage);
       GraphicsUtil.switchToWidth(g, 1);
     }
     GraphicsUtil.switchToWidth(g, 1);
@@ -314,7 +316,7 @@ public class ShiftRegister extends InstanceFactory {
     if (LastBlock) {
       GraphicsUtil.switchToWidth(g, DataWidth);
       g.drawLine(
-          real_xpos + blockwidth, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
+          real_xpos + blockwidth + line_fix, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
       painter.drawPort(OUT);
       GraphicsUtil.switchToWidth(g, 1);
     }
@@ -322,10 +324,10 @@ public class ShiftRegister extends InstanceFactory {
       GraphicsUtil.switchToWidth(g, DataWidth);
       if (current_stage == 0)
         g.drawLine(
-            real_xpos + blockwidth, real_ypos + 20, real_xpos + blockwidth + 10, real_ypos + 20);
+            real_xpos + blockwidth + line_fix, real_ypos + 20, real_xpos + blockwidth + 10, real_ypos + 20);
       else
         g.drawLine(
-            real_xpos + blockwidth, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
+            real_xpos + blockwidth + line_fix, real_ypos + 10, real_xpos + blockwidth + 10, real_ypos + 10);
       painter.drawPort(6 + 2 * current_stage + 1);
       GraphicsUtil.switchToWidth(g, 1);
     }

--- a/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
+++ b/src/main/java/com/cburch/logisim/util/GraphicsUtil.java
@@ -240,4 +240,9 @@ public class GraphicsUtil {
   public static final int V_BOTTOM = 2;
 
   public static final int V_CENTER_OVERALL = 3;
+
+  public static final int CONTROL_WIDTH = 2;
+  public static final int NEGATED_WIDTH = 2;
+  public static final int DATA_SINGLE_WIDTH = 3;
+  public static final int DATA_MULTI_WIDTH = 4;
 }


### PR DESCRIPTION
Using System.currentTimeMillis() made clock ticks like 2kHz impossible
due to creating a 1ms wait, which meant that 1kHz and 2kHz options were
essentially the same.

Some of the memory components drew things with several lines instead of polylines, for essentially the same thing. I also modified the clock to use a polyline instead of two lines, as it looks better.

The 1/0 in the flip flops wasn't centered, so that is also fixed.