### PR TITLE
Bug fix in DemultiplexerHDLGeneratorFactory.java

### DIFF
--- a/src/main/java/com/cburch/logisim/std/gates/AbstractGateHDLGenerator.java
+++ b/src/main/java/com/cburch/logisim/std/gates/AbstractGateHDLGenerator.java
@@ -282,7 +282,7 @@ public class AbstractGateHDLGenerator extends AbstractHDLGeneratorFactory {
         Lines.add("   genvar n;");
         Lines.add("   generate");
         Lines.add("      for (n = 0 ; n < " + BitWidthString + " ; n = n + 1)");
-        Lines.add("         begin: bit");
+        Lines.add("         begin: bits");
         Spaces += "         ";
         IndexString = "[n]";
       }

--- a/src/main/java/com/cburch/logisim/std/plexers/DemultiplexerHDLGeneratorFactory.java
+++ b/src/main/java/com/cburch/logisim/std/plexers/DemultiplexerHDLGeneratorFactory.java
@@ -72,7 +72,7 @@ public class DemultiplexerHDLGeneratorFactory extends AbstractHDLGeneratorFactor
       }
       String binValue = IntToBin(i, nr_of_select_bits, HDLType);
       if (HDLType.equals(VHDL)) {
-        Contents.add("   DemuxOut_" + i + Space + "<= DemuxIn WHEN sel = " + binValue + " AND");
+        Contents.add("   DemuxOut_" + i + Space + "<= DemuxIn WHEN Sel = " + binValue + " AND");
         if (attrs.getValue(StdAttr.WIDTH).getWidth() > 1) {
           Contents.add("                               Enable = '1' ELSE (OTHERS => '0');");
         } else {
@@ -83,7 +83,7 @@ public class DemultiplexerHDLGeneratorFactory extends AbstractHDLGeneratorFactor
             "   assign DemuxOut_"
                 + Integer.toString(i)
                 + Space
-                + " = (Enable&(sel == "
+                + " = (Enable&(Sel == "
                 + binValue
                 + " )) ? DemuxIn : 0;");
       }


### PR DESCRIPTION
Generated Demultiplexers have an input named "Sel" but their internal logic references "sel", resulting in unusable generated HDL. Fixed this name mismatch for internal signals to preserve input name.