### PR TITLE
Fix dateFormat in polish localization

### DIFF
--- a/src/main/resources/resources/logisim/pl/util.properties
+++ b/src/main/resources/resources/logisim/pl/util.properties
@@ -33,7 +33,7 @@ dlogOkButton = OK
 #
 # LocaleManager.java
 #
-dateFormat = dd.MM.rrrr HH:mm:ss
+dateFormat = dd.MM.yyyy HH:mm:ss
 LMacceptAllFileFilterText = Wszystkie pliki
 LMcancelButtonText = Anuluj
 LMcancelButtonToolTipText = Przerwij okno dialogowe wyboru pliku


### PR DESCRIPTION
The wrong dateFormat caused an exception at start up when a polish
locale is active.

This fixes issue #477.