### PR TITLE
Fix buzzer not resetting on simulation reset

### DIFF
--- a/src/main/java/com/cburch/logisim/circuit/CircuitState.java
+++ b/src/main/java/com/cburch/logisim/circuit/CircuitState.java
@@ -40,6 +40,7 @@ import com.cburch.logisim.instance.InstanceData;
 import com.cburch.logisim.instance.InstanceFactory;
 import com.cburch.logisim.instance.InstanceState;
 import com.cburch.logisim.proj.Project;
+import com.cburch.logisim.std.io.extra.Buzzer;
 import com.cburch.logisim.std.memory.Ram;
 import com.cburch.logisim.std.memory.RamState;
 import com.cburch.logisim.std.wiring.Clock;
@@ -432,6 +433,8 @@ public class CircuitState implements InstanceData {
         Ram ram = (Ram) comp.getFactory();
         boolean remove = ram.reset(this, Instance.getInstanceFor(comp));
         if (remove) componentData.put(comp, null);
+      } else if (comp.getFactory() instanceof Buzzer) {
+        Buzzer.StopBuzzerSound(comp, this);
       } else if (!(comp.getFactory() instanceof SubcircuitFactory)) {
         if (componentData.get(comp) instanceof ComponentDataGuiProvider)
           ((ComponentDataGuiProvider)componentData.get(comp)).destroy();


### PR DESCRIPTION
If one tries to reset the simulation while a buzzer is active, the stream is not properly closed and the whole program becomes unuseable, because since the buzzer initializes a new Data object, it's impossible to turn off the tone without closing Logisim completely. This fixes the problem by preventively calling StopBuzzerSound on all buzzers when the simulation is reset.