### PR TITLE
Change macos app name to start with upper case L

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ You can find already compiled versions of the code [here](https://github.com/red
 Starting with V3.4.1 the following compiled versions are available:
 * logisim-evolution_`<version>`-1_amd64.deb  : Self contained debian installer (also ubuntu).
 * logisim-evolution_`<version>`-1.x86_64.rpm : Self contained Redhat installer.
-* logisim-evolution_`<version>`.dmg          : Self contained Mac OsX installer.
+* Logisim-evolution_`<version>`.dmg          : Self contained Mac OsX installer.
 * logisim-evolution_`<version>`.msi          : Self contained Windows installer.
 
-If you want to have the latest development version you can build/run it by cloning the repository on your local machine and making sure that at least [OpenJDK](https://adoptopenjdk.net/) 9 is installed.
+If you want to have the latest development version you can build/run it by cloning the repository on your local machine and making sure that at least [OpenJDK](https://adoptopenjdk.net/) 11 is installed.
 Once this is done, enter the directory and execute:
 ```bash
 ./gradlew run

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,15 +60,16 @@ tasks.register("jpackage") {
     dependsOn("shadowJar")
     doFirst {
       val folder = File("$buildDir/dist")
-        if (!folder.exists()) {
+      if (!folder.exists()) {
         if (!folder.mkdirs()) throw GradleException("Unable to create directory \"$buildDir/dist\"")
       }
     }
     doLast {
+      val appname = project.name.substring(0,1).toUpperCase() + project.name.substring(1)
       val df = SimpleDateFormat("yyyy")
-        val year = df.format(Date())
-        val parameters = ArrayList<String>()
-        val javaHome = System.getProperty("java.home") ?: throw GradleException("java.home is not set")
+      val year = df.format(Date())
+      val parameters = ArrayList<String>()
+      val javaHome = System.getProperty("java.home") ?: throw GradleException("java.home is not set")
       val cmd = javaHome + File.separator + "bin" + File.separator + "jpackage"
       parameters.add(if (cmd.contains(" ")) "\"" + cmd + "\"" else cmd)
       parameters.add("--input")
@@ -77,8 +78,6 @@ tasks.register("jpackage") {
       parameters.add("com.cburch.logisim.Main")
       parameters.add("--main-jar")
       parameters.add(project.name + '-' + project.version + "-all.jar")
-      parameters.add("--name")
-      parameters.add(project.name)
       parameters.add("--app-version")
       parameters.add(project.version as String)
       parameters.add("--copyright")
@@ -86,6 +85,8 @@ tasks.register("jpackage") {
       parameters.add("--dest")
       parameters.add("build/dist")
       if (OperatingSystem.current().isLinux) {
+         parameters.add("--name")
+         parameters.add(project.name)
          parameters.add("--file-associations")
          parameters.add("support/jpackage/linux/file.jpackage")
          parameters.add("--icon")
@@ -108,6 +109,8 @@ tasks.register("jpackage") {
             throw GradleException("Error while executing jpackage")
          }
       } else if (OperatingSystem.current().isWindows) {
+         parameters.add("--name")
+         parameters.add(project.name)
          parameters.add("--file-associations")
          parameters.add("support/jpackage/windows/file.jpackage")
          parameters.add("--icon")
@@ -126,6 +129,8 @@ tasks.register("jpackage") {
             throw GradleException("Error while executing jpackage")
          }
       } else if (OperatingSystem.current().isMacOsX) {
+         parameters.add("--name")
+         parameters.add(appname)
          parameters.add("--resource-dir")
          parameters.add("support/jpackage/macos")
          parameters.add("--file-associations")

--- a/support/jpackage/macos/Logisim-evolution-post-image.sh
+++ b/support/jpackage/macos/Logisim-evolution-post-image.sh
@@ -5,7 +5,7 @@ if [ -d $appcontents ] ; then
   if [ -f Info.plist ] ; then
     awk '/Unknown/{sub(/Unknown/,"public.app-category.education")};{print};/NSHighResolutionCapable/{print "  <string>true</string>"; print "  <key>NSSupportsAutomaticGraphicsSwitching</key>"}' \
         Info.plist > I.plist
-    if [ -f I.plist ] ; then
+    if [ -s I.plist ] ; then
       mv I.plist Info.plist
     fi
   fi

--- a/support/jpackage/macos/file.jpackage
+++ b/support/jpackage/macos/file.jpackage
@@ -1,4 +1,4 @@
 extension=circ
 mime-type=application/octet-stream
-icon=support/jpackage/macos/logisim-evolution-circ.icns
+icon=support/jpackage/macos/Logisim-evolution-circ.icns
 description=Logisim circuit file


### PR DESCRIPTION
This PR changes the macos dmg and app names to start with uppercase L.
It also makes changes in support/jpackage/macos that should allow the build to work properly on case-sensitive mac file systems.

It should now be easy to test uppercase L on either Linux of Windows systems if desired by changing the --name parameter to appname.

I noticed in changing the name of the dmg in the README.md that it says to use at least OpenJDK 9. I updated that to 11.