### PR TITLE
Handle invalid bit width in test vector file

### DIFF
--- a/src/main/java/com/cburch/logisim/data/TestVector.java
+++ b/src/main/java/com/cburch/logisim/data/TestVector.java
@@ -131,7 +131,11 @@ public class TestVector {
             throw new IOException("Test Vector header format error: bad spec: " + t);
 
           columnName[i] = t.substring(0, s);
-          int w = new Integer(t.substring(s + 1, e)).intValue();
+          int w = 0;
+          try {
+            w = Integer.parseInt(t.substring(s + 1, e));
+          } catch (NumberFormatException ex) {
+          }
 
           if (w < 1 || w > 32)
             throw new IOException("Test Vector header format error: bad width: " + t);


### PR DESCRIPTION
If a `java.lang.NumberFormatException` occurs when parsing a bit width from a test vector file, then display an error dialog with a message like _Test vector in "test2.txt" could not be parsed. Detail: Test Vector header format error: bad width: O[2.0]._

Fixes #502 