### PR TITLE
Allow 64 bit Test Vector file

### DIFF
--- a/src/main/java/com/cburch/logisim/data/TestVector.java
+++ b/src/main/java/com/cburch/logisim/data/TestVector.java
@@ -133,7 +133,7 @@ public class TestVector {
           columnName[i] = t.substring(0, s);
           int w = new Integer(t.substring(s + 1, e)).intValue();
 
-          if (w < 1 || w > 32)
+          if (w < 1 || w > 64)
             throw new IOException("Test Vector header format error: bad width: " + t);
           columnWidth[i] = BitWidth.create(w);
         }

--- a/src/main/java/com/cburch/logisim/data/Value.java
+++ b/src/main/java/com/cburch/logisim/data/Value.java
@@ -143,8 +143,6 @@ public class Value {
 
       value *= radix;
       unknown *= radix;
-      if ((value >> (radix == 10 ? 33 : w)) != 0 || (unknown >> 36) != 0)
-        throw new Exception("too many bits in \"" + t + "\"");
 
       if (radix != 10) {
         if (d == -1) unknown |= (radix - 1);


### PR DESCRIPTION
Allow 64 bit width in Test Vector file header.

Removed unnecessary "too many bits" check whilst reading digits of Test Vector file values. This test does not work for 64 bits (`value >> 64` always returns the same 64 bit `value`). The test at the end of the loop after parsing all digits is already adequate for testing "too many bits".

Fixes #507 