### PR TITLE
Initialize Slider value attribute to 64 bit zero value

### DIFF
--- a/src/main/java/com/cburch/logisim/std/io/extra/Slider.java
+++ b/src/main/java/com/cburch/logisim/std/io/extra/Slider.java
@@ -214,7 +214,7 @@ public class Slider extends InstanceFactory {
           StdAttr.DEFAULT_LABEL_FONT,
           true,
           LEFT_TO_RIGHT,
-          0
+          Long.valueOf(0)
         });
     setFacingAttribute(StdAttr.FACING);
     setIconName("slider.gif");


### PR DESCRIPTION
The Slider value attribute is used in class `com.cburch.logisim.std.io.extra.Slider` as a 64 bit value, so must be initialized as a 64 bit value with type `java.lang.Long` instead of type `java.lang.Integer`, to avoid java casting exceptions.

Fixes #509