### PR TITLE
Loop Truth Table by index because modified in loop

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
+++ b/src/main/java/com/cburch/logisim/analyze/model/TruthTable.java
@@ -661,7 +661,8 @@ public class TruthTable {
       // force an Entry column of each row.input to 'x', then remove it
       int b = (1 << (oldCount - 1 - index)); // _0001000
       boolean[] changed = new boolean[columns.size()];
-      for (Row r : rows) {
+      for (int i = 0; i < rows.size(); i++) {
+        Row r = rows.get(i);
         if (r.inputs[index] == Entry.DONT_CARE)
           continue;
         setDontCare(r, b, true, changed);


### PR DESCRIPTION
When modifying Truth Table model, loop through the Truth Table rows by index, because the Table is modified inside the loop.

Using a `for (Row r : rows)` iterator throws a `java.util.ConcurrentModificationException`.

A loop by index was used in the original implementation, but was recently changed to an iterator in e1d7ce0f6bee88ed460ffcaa9e6ddcfacd1dcbd9.

Fixes #511 