### PR TITLE
Fixed alignment of inversion bars in Combinatorial Analysis Expressions

### DIFF
--- a/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
@@ -78,7 +78,7 @@ public class ExpressionRenderData {
     this.notation = notation;
     NOT_SEP = AppPreferences.getScaled(3);
     EXTRA_LEADING = AppPreferences.getScaled(4);
-    EXPRESSION_BASE_FONT = AppPreferences.getScaledFont(new Font("Monospaced", Font.PLAIN, 14));
+    EXPRESSION_BASE_FONT = AppPreferences.getScaledFont(new Font(Font.MONOSPACED, Font.PLAIN, 14));
     BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
     Graphics2D g = (Graphics2D)img.getGraphics().create();
     if (AppPreferences.AntiAliassing.getBoolean()) {

--- a/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
+++ b/src/main/java/com/cburch/logisim/analyze/data/ExpressionRenderData.java
@@ -251,7 +251,7 @@ public class ExpressionRenderData {
      */
     String sub = s.substring(0, end);
     if (replaceSpaces) {
-     sub = sub.replaceAll("[ ()\\u22C5]","_");
+     sub = sub.replaceAll(" ","_");
     }
     AttributedString as = new AttributedString(sub);
     as.addAttribute(TextAttribute.FAMILY, EXPRESSION_BASE_FONT.getFamily());
@@ -308,9 +308,9 @@ public class ExpressionRenderData {
   private int getWidth(FontRenderContext ctx, String s, int end, ArrayList<Range> subs, ArrayList<Range> marks) {
     if (end == 0) return 0;
     AttributedString as = style(s, end, subs, marks, true);
-    /* The TextLayout class will omit trailing spaces, incorrectly format parenthesis/cdot,
+    /* The TextLayout class will omit trailing spaces,
      * hence the width is incorrectly calculated. Therefore in the previous method we can
-     * replace the spaces and parenthesis by underscores to prevent this problem; maybe
+     * replace the spaces by underscores to prevent this problem; maybe
      * there is a more intelligent way.
      */
     TextLayout layout = new TextLayout(as.getIterator(), ctx);


### PR DESCRIPTION
Removed special logic for converting parentheses and dot characters to underscores before calculating width of expression text.

Java returns the correct widths for strings containing these characters, so no special logic is needed.

The only special case is spaces. Java will return the same width for "abc" and "abc ", so we do need to convert each space to an underscore, before calculating widths.

Attaching screenshots of expressions in #284 after my changes on Windows 10 and Ubuntu Linux, both with OpenJDK 11. I have no Mac for testing.

X = NOT A AND NOT B OR NOT A AND D OR NOT A AND C OR B AND C AND D
Y = (A OR B OR NOT C) AND (A OR NOT C OR NOT D) AND (A OR NOT B OR C OR D) AND (NOT A OR NOT B OR NOT D) AND (NOT A OR NOT B OR NOT C)

![windows-10-expression-284](https://user-images.githubusercontent.com/1910647/111364988-38ba1b00-8692-11eb-8312-a6b29fa1ebc4.png)

![linux-expression-284](https://user-images.githubusercontent.com/1910647/111365121-643d0580-8692-11eb-9db8-f593c4b1630d.png)

Fixes #284