### PR TITLE
Use 64-bit arithmetic for 0/1 pin display of 64-bit Counter

### DIFF
--- a/src/main/java/com/cburch/logisim/std/memory/Counter.java
+++ b/src/main/java/com/cburch/logisim/std/memory/Counter.java
@@ -405,7 +405,7 @@ public class Counter extends InstanceFactory implements DynamicElementProvider {
       String value = "";
       if (val.isFullyDefined()) {
         g.setColor(Color.LIGHT_GRAY);
-        value = ((1 << BitNr) & val.toLongValue()) != 0 ? "1" : "0";
+        value = ((1L << BitNr) & val.toLongValue()) != 0 ? "1" : "0";
       } else if (val.isUnknown()) {
         g.setColor(Color.BLUE);
         value = "?";


### PR DESCRIPTION
Use 64-bit mask, not 32-bit mask, for determining "0" and "1" labels for Counter component pin display.

Fixes #527